### PR TITLE
CommandBar by ID

### DIFF
--- a/Source/ExcelDna.Integration/ExcelCommandBars.cs
+++ b/Source/ExcelDna.Integration/ExcelCommandBars.cs
@@ -38,29 +38,6 @@ namespace ExcelDna.Integration.CustomUI
 {
     public delegate Bitmap GetImageDelegate(string imageName);
 
-    //public class ExcelCommandBars
-    //{
-    //    public ExcelCommandBars()
-    //    {
-    //    }
-
-    //    public virtual string GetCustomUI()
-    //    {
-    //    }
-
-    //    public virtual object GetImage(string imageName)
-    //    {
-
-    //    }
-
-    //    public CommandBarControls Controls
-    //    {
-    //        get
-    //        {
-    //        }
-    //    }
-    //}
-
     public static class ExcelCommandBarUtil
     {
         // List of loaded CustomUI 
@@ -571,16 +548,6 @@ namespace ExcelDna.Integration.CustomUI
                 return Convert.ToInt32(i);
             }
         }
-
-        //public event EventHandler OnUpdate
-        //{
-        //    add
-        //    {
-        //    }
-        //    remove
-        //    {
-        //    }
-        //}
     }
 
     public class CommandBarControl
@@ -941,11 +908,6 @@ namespace ExcelDna.Integration.CustomUI
         }
     }
 
-    //public class CommandBarButtonClickEventArgs : EventArgs
-    //{
-    //    public bool CancelDefault;
-    //}
-
     public class CommandBarButton : CommandBarControl
     {
         internal CommandBarButton(object commandBarCom)
@@ -1003,16 +965,6 @@ namespace ExcelDna.Integration.CustomUI
                 ComObjectType.InvokeMember("ShortcutText", BindingFlags.SetProperty, null, ComObject, new object[] { value });
             }
         }
-
-        //public event EventHandler<CommandBarButtonClickEventArgs> Click
-        //{
-        //    add
-        //    {
-        //    }
-        //    remove
-        //    {
-        //    }
-        //}
     }
 
     public class CommandBarPopup : CommandBarControl

--- a/Source/ExcelDna.Integration/ExcelCommandBars.cs
+++ b/Source/ExcelDna.Integration/ExcelCommandBars.cs
@@ -121,8 +121,8 @@ namespace ExcelDna.Integration.CustomUI
             {
                 if (childNode.Name == "commandBar")
                 {
-                    string barName = childNode.Attributes["name"].Value;
-                    CommandBar bar = GetCommandBarFromName(excelApp, barName);
+                    string barName;
+                    CommandBar bar = GetCommandBarFromIdOrName(excelApp, childNode.Attributes, out barName);
                     if (bar != null)
                     {
                         AddControls(bar.Controls, childNode.ChildNodes, getImage);
@@ -156,8 +156,8 @@ namespace ExcelDna.Integration.CustomUI
             {
                 if (childNode.Name == "commandBar")
                 {
-                    string barName = childNode.Attributes["name"].Value;
-                    CommandBar bar = GetCommandBarFromName(excelApp, barName);
+                    string barName;
+                    CommandBar bar = GetCommandBarFromIdOrName(excelApp, childNode.Attributes, out barName);
                     if (bar != null)
                     {
                         RemoveControls(bar.Controls, childNode.ChildNodes);
@@ -171,18 +171,50 @@ namespace ExcelDna.Integration.CustomUI
             }
         }
 
-        private static CommandBar GetCommandBarFromName(Application excelApp, string barName)
+        //We cannot rely only on name to recover the proper CommandBar so we have the possibility to use the ID (which is used in priority).
+        //Indeed there are two CommandBar for "Cell" see  http://msdn.microsoft.com/en-us/library/office/gg469862(v=office.14).aspx
+        //However, at the time of the writing there is a mistake: "Application.CommandBars(Application.CommandBars("Cell").Index + 3)" is false in practice
+        // Note that the Id property is only available
+        private static CommandBar GetCommandBarFromIdOrName(Application excelApp, XmlAttributeCollection nodeAttributes, out string barName)
         {
-            CommandBar bar = null;
-            for (int i = 1; i <= excelApp.CommandBars.Count; i++)
+            var id =  nodeAttributes["id"];
+            var name = nodeAttributes["name"];
+            if(name ==null) throw new ArgumentException("commandBar attributes must contain name");
+
+            barName = name.Value;
+            if (id != null)
             {
-                if (excelApp.CommandBars[i].Name == barName)
+                string barId = id.Value;
+                CommandBar bar = null;
+                for (int i = 1; i <= excelApp.CommandBars.Count; i++)
                 {
-                    bar = excelApp.CommandBars[i];
-                    break;
+                    var currentBar = excelApp.CommandBars[i];
+                    if (currentBar.Type == MsoBarType.msoBarTypePopup)
+                    {
+                        var currentBarPopup = new CommandBarPopup(currentBar.GetComObject());
+                        if (currentBarPopup.Id == barId)
+                        {
+                            bar = currentBar;
+                            break;
+                        }
+                    }
                 }
+                return bar;
             }
-            return bar;
+            else
+            {
+                
+                CommandBar bar = null;
+                for (int i = 1; i <= excelApp.CommandBars.Count; i++)
+                {
+                    if (excelApp.CommandBars[i].Name == barName)
+                    {
+                        bar = excelApp.CommandBars[i];
+                        break;
+                    }
+                }
+                return bar;
+            }
         }
 
         private static void AddControls(CommandBarControls parentControls, XmlNodeList xmlNodes, GetImageDelegate getImage)
@@ -482,6 +514,14 @@ namespace ExcelDna.Integration.CustomUI
             }
         }
 
+        public MsoBarType Type
+        {
+            get
+            {
+                return (MsoBarType)ComObjectType.InvokeMember("Type", BindingFlags.GetProperty, null, ComObject, null);
+            }
+        }
+
         public CommandBarControl FindControl(object type, object id, object tag, object visible, object recursive)
         {
             object result = ComObjectType.InvokeMember("FindControl", BindingFlags.InvokeMethod, null, ComObject, new object[] { type, id, tag, visible, recursive });
@@ -742,7 +782,16 @@ namespace ExcelDna.Integration.CustomUI
                 return (int)ComObjectType.InvokeMember("Index", BindingFlags.GetProperty, null, ComObject, null);
             }
         }
-            
+
+        public string Id
+        {
+            get
+            {
+                object controls = ComObjectType.InvokeMember("Id", BindingFlags.GetProperty, null, ComObject, null);
+                return controls.ToString();
+            }
+        }
+
         public void Delete(object Temporary)
         {
             ComObjectType.InvokeMember("Delete", BindingFlags.InvokeMethod, null, ComObject, new object[] { Temporary });
@@ -1048,5 +1097,12 @@ namespace ExcelDna.Integration.CustomUI
         msoControlLabelEx = 24,
         msoControlWorkPane = 25,
         msoControlAutoCompleteCombo = 26,
+    }
+
+    public enum MsoBarType
+    {
+        msoBarTypeNormal = 0,
+        msoBarTypeMenuBar = 1,
+        msoBarTypePopup = 2,
     }
 }

--- a/Source/ExcelDna.Integration/ExcelCommandBars.cs
+++ b/Source/ExcelDna.Integration/ExcelCommandBars.cs
@@ -122,15 +122,7 @@ namespace ExcelDna.Integration.CustomUI
                 if (childNode.Name == "commandBar")
                 {
                     string barName = childNode.Attributes["name"].Value;
-                    CommandBar bar = null;
-                    for (int i = 1; i <= excelApp.CommandBars.Count; i++)
-                    {
-                        if (excelApp.CommandBars[i].Name == barName)
-                        {
-                            bar = excelApp.CommandBars[i];
-                            break;
-                        }
-                    }
+                    CommandBar bar = GetCommandBarFromName(excelApp, barName);
                     if (bar != null)
                     {
                         AddControls(bar.Controls, childNode.ChildNodes, getImage);
@@ -165,15 +157,7 @@ namespace ExcelDna.Integration.CustomUI
                 if (childNode.Name == "commandBar")
                 {
                     string barName = childNode.Attributes["name"].Value;
-                    CommandBar bar = null;
-                    for (int i = 1; i <= excelApp.CommandBars.Count; i++)
-                    {
-                        if (excelApp.CommandBars[i].Name == barName)
-                        {
-                            bar = excelApp.CommandBars[i];
-                            break;
-                        }
-                    }
+                    CommandBar bar = GetCommandBarFromName(excelApp, barName);
                     if (bar != null)
                     {
                         RemoveControls(bar.Controls, childNode.ChildNodes);
@@ -185,6 +169,20 @@ namespace ExcelDna.Integration.CustomUI
                     }
                 }
             }
+        }
+
+        private static CommandBar GetCommandBarFromName(Application excelApp, string barName)
+        {
+            CommandBar bar = null;
+            for (int i = 1; i <= excelApp.CommandBars.Count; i++)
+            {
+                if (excelApp.CommandBars[i].Name == barName)
+                {
+                    bar = excelApp.CommandBars[i];
+                    break;
+                }
+            }
+            return bar;
         }
 
         private static void AddControls(CommandBarControls parentControls, XmlNodeList xmlNodes, GetImageDelegate getImage)


### PR DESCRIPTION
There are two CommandBar with name "Cell": one for the usual right click on a cell and one for the "PageBreakView" [see this article](http://msdn.microsoft.com/en-us/library/office/gg469862(v=office.14).aspx). When passing to the method *ExcelCommandBarUtil.LoadCommandBar* an xml argument of the form

    <commandBars xmlns='http://schemas.excel-dna.net/office/2003/01/commandbars' > 
      <commandBar name='Cell'>
      <button caption='Hello' enabled='true' onAction='SayHello'/>
      </commandBar>
    </commandBars>"

the first CommandBar whose name is "Cell" is returned. We have found situations where this first CommandBar is the "Cell" for PageBreakView and not the usual one.

In this pull request we add the possibility to specify the id of the CommandBar to avoid such situations. If an attribute *id* is present then it will be used to retrieve the CommandBar instead of *name*. If no *id* attribute is present then the *name* is used as a fallback (to avoid breaking existing code). Note that the attribute *name* is mandatory in both cases.

Now if you want to retrieve the usual "Cell" CommandBar you can use its *id* 424.

    <commandBars xmlns='http://schemas.excel-dna.net/office/2003/01/commandbars' > 
      <commandBar name='Cell' id='424'>
      <button caption='Hello' enabled='true' onAction='SayHello'/>
      </commandBar>
    </commandBars>"
