### PR TITLE
ExcelDnaPack: Read source item contents as binary instead of assuming UTF-8

### DIFF
--- a/Source/ExcelDnaPack/PackProgram.cs
+++ b/Source/ExcelDnaPack/PackProgram.cs
@@ -338,7 +338,7 @@ Other assemblies are packed if marked with Pack=""true"" in the .dna file.
                             break;
                         }
                         string name = Path.GetFileNameWithoutExtension(path).ToUpperInvariant() + "_" + lastPackIndex++ + Path.GetExtension(path).ToUpperInvariant();
-                        byte[] sourceBytes = Encoding.UTF8.GetBytes(File.ReadAllText(path));
+                        byte[] sourceBytes = File.ReadAllBytes(path);
                         ru.AddSource(sourceBytes, name);
                         source.Path = "packed:" + name;
                     }


### PR DESCRIPTION
Resolves issue #2