### PR TITLE
Add .mailmap to root, to fix committers identities

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,8 @@
+Govert van Drimmelen <govert@icon.co.za> govert_cp <SND\govert_cp>
+Govert van Drimmelen <govert@icon.co.za> govert_cp <2b25b41bbf01b7d265f78f98bda07e53ff173630NvGJUJxL>
+Govert van Drimmelen <govert@icon.co.za> TFSSERVICE <RNO\_TFSSERVICE>
+Govert van Drimmelen <govert@icon.co.za> MCLWEB <RNO\_MCLWEB>
+Govert van Drimmelen <govert@icon.co.za> [TFS09]\Project Collection Service Accounts <vstfs:///Framework/IdentityDomain/a83551a4-30f6-4d81-a974-c6ced450ddbf\Project Collection Service Accounts>
+Govert van Drimmelen <govert@icon.co.za> Project Collection Service Accounts <vstfs:///Framework/IdentityDomain/a83551a4-30f6-4d81-a974-c6ced450ddbf\Project Collection Service Accounts>
+Caio Proiete <caio.proiete@gmail.com> Caio Proiete <cproiete@nephilacapital.com>
+


### PR DESCRIPTION
I've just noticed that on commit [519b64](https://github.com/Excel-DNA/ExcelDna/commits?author=cproiete) I had the wrong e-mail address configured on my laptop and it was linking to the wrong GitHub user (`cproiete` instead of `caioproiete`), so I thought I should fix it with a Git `.mailmap`.

Whilst I was at it, I fixed other identities that were incorrect as well, and added the corresponding mappings.

#### Before:

```
$ git shortlog -sne

  108  govert_cp <SND\govert_cp>
  105  govert_cp <2b25b41bbf01b7d265f78f98bda07e53ff173630NvGJUJxL>
   76  Govert van Drimmelen <govert@ic...>
    2  Caio Proiete <caio.proiete@gm...>
    2  MCLWEB <RNO\_MCLWEB>
    2  Paul Harrington <phrrngtn@pa...>
    2  Project Collection Service Accounts <vstfs:///Framework/IdentityDomain/a
    2  TFSSERVICE <RNO\_TFSSERVICE>
    2  [TFS09]\Project Collection Service Accounts <vstfs:///Framework/Identity
```


#### After:
```
$ git shortlog -sne

  297  Govert van Drimmelen <govert@ic...>
    3  Caio Proiete <caio.proiete@gm...>
    2  Paul Harrington <phrrngtn@pa...>
```

Thanks,
Caio Proiete
