### PR TITLE
* add /NC option (no Compression) for packing without lzma

### DIFF
--- a/Source/ExcelDnaPack/ExcelDnaPack.csproj
+++ b/Source/ExcelDnaPack/ExcelDnaPack.csproj
@@ -28,6 +28,8 @@
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>3</LangVersion>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>true</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Source/ExcelDnaPack/PackProgram.cs
+++ b/Source/ExcelDnaPack/PackProgram.cs
@@ -20,10 +20,11 @@ ExcelDnaPack is a command-line utility to pack ExcelDna add-ins into a single .x
 
 Usage: ExcelDnaPack.exe dnaPath [/O outputPath] [/Y] 
 
-  dnaPath         The path to the primary .dna file for the ExcelDna add-in.
-  /Y              If the output .xll exists, overwrite without prompting.
-  /NoCompression  no compress (LZMA) of resources
-  /O outPath      Output path - default is <dnaPath>-packed.xll.
+  dnaPath           The path to the primary .dna file for the ExcelDna add-in.
+  /Y                If the output .xll exists, overwrite without prompting.
+  /NoCompression    no compress (LZMA) of resources
+  /NoMultiThreading no multi threading to ensure deterministic packing order
+  /O outPath        Output path - default is <dnaPath>-packed.xll.
 
 Example: ExcelDnaPack.exe MyAddins\FirstAddin.dna
 		 The packed add-in file will be created as MyAddins\FirstAddin-packed.xll.
@@ -84,6 +85,7 @@ Other assemblies are packed if marked with Pack=""true"" in the .dna file.
 			string xllOutputPath = Path.Combine(dnaDirectory, dnaFilePrefix + "-packed.xll");
             bool overwrite = false;
             bool compress = true;
+            bool multithreading = true;
 
 			if (!File.Exists(dnaPath))
 			{
@@ -114,6 +116,12 @@ Other assemblies are packed if marked with Pack=""true"" in the .dna file.
                     {
                         compress = false;
                     }
+                    else
+                    if (args[i].Equals("/NoMultiThreading", StringComparison.CurrentCultureIgnoreCase))
+                    {
+                        multithreading = false;
+                    }
+                    
                 }
             }
 
@@ -189,7 +197,7 @@ Other assemblies are packed if marked with Pack=""true"" in the .dna file.
 			string packedName = null;
 			if (integrationPath != null)
 			{
-				packedName = ru.AddAssembly(integrationPath, compress);
+				packedName = ru.AddAssembly(integrationPath, compress, multithreading);
 			}
 			if (packedName == null)
 			{
@@ -200,11 +208,11 @@ Other assemblies are packed if marked with Pack=""true"" in the .dna file.
 			}
 			if (File.Exists(configPath))
 			{
-				ru.AddFile(File.ReadAllBytes(configPath), "__MAIN__",ResourceHelper.TypeName.CONFIG, false);  // Name here must exactly match name in ExcelDnaLoad.cpp.
+				ru.AddFile(File.ReadAllBytes(configPath), "__MAIN__",ResourceHelper.TypeName.CONFIG, false, multithreading);  // Name here must exactly match name in ExcelDnaLoad.cpp.
 			}
 			byte[] dnaBytes = File.ReadAllBytes(dnaPath);
-			byte[] dnaContentForPacking = PackDnaLibrary(dnaBytes, dnaDirectory, ru, compress);
-			ru.AddFile(dnaContentForPacking, "__MAIN__",ResourceHelper.TypeName.DNA, false); // Name here must exactly match name in DnaLibrary.Initialize.
+			byte[] dnaContentForPacking = PackDnaLibrary(dnaBytes, dnaDirectory, ru, compress, multithreading);
+			ru.AddFile(dnaContentForPacking, "__MAIN__",ResourceHelper.TypeName.DNA, false, multithreading); // Name here must exactly match name in DnaLibrary.Initialize.
 			ru.EndUpdate();
 			Console.WriteLine("Completed Packing {0}.", xllOutputPath);
 #if DEBUG
@@ -217,7 +225,7 @@ Other assemblies are packed if marked with Pack=""true"" in the .dna file.
 
 		static int lastPackIndex = 0;
 
-		static byte[] PackDnaLibrary(byte[] dnaContent, string dnaDirectory, ResourceHelper.ResourceUpdater ru, bool compress)
+		static byte[] PackDnaLibrary(byte[] dnaContent, string dnaDirectory, ResourceHelper.ResourceUpdater ru, bool compress, bool multithreading)
 		{
 			DnaLibrary dna = DnaLibrary.LoadFrom(dnaContent, dnaDirectory);
             if (dna == null)
@@ -237,13 +245,13 @@ Other assemblies are packed if marked with Pack=""true"" in the .dna file.
 						if (Path.GetExtension(path).Equals(".DNA", StringComparison.OrdinalIgnoreCase))
 						{
 							string name = Path.GetFileNameWithoutExtension(path).ToUpperInvariant() + "_" + lastPackIndex++ + ".DNA";
-							byte[] dnaContentForPacking = PackDnaLibrary(File.ReadAllBytes(path), Path.GetDirectoryName(path), ru, compress);
-							ru.AddFile(dnaContentForPacking, name, ResourceHelper.TypeName.DNA, compress);
+							byte[] dnaContentForPacking = PackDnaLibrary(File.ReadAllBytes(path), Path.GetDirectoryName(path), ru, compress, multithreading);
+							ru.AddFile(dnaContentForPacking, name, ResourceHelper.TypeName.DNA, compress, multithreading);
 							ext.Path = "packed:" + name;
 						}
 						else
 						{
-							string packedName = ru.AddAssembly(path, compress);
+							string packedName = ru.AddAssembly(path, compress, multithreading);
 							if (packedName != null)
 							{
 								ext.Path = "packed:" + packedName;
@@ -344,7 +352,7 @@ Other assemblies are packed if marked with Pack=""true"" in the .dna file.
 					}
 					
 					// It worked!
-					string packedName = ru.AddAssembly(path, compress);
+					string packedName = ru.AddAssembly(path, compress, multithreading);
 					if (packedName != null)
 					{
 						rf.Path = "packed:" + packedName;
@@ -363,7 +371,7 @@ Other assemblies are packed if marked with Pack=""true"" in the .dna file.
                     }
                     string name = Path.GetFileNameWithoutExtension(path).ToUpperInvariant() + "_" + lastPackIndex++ + Path.GetExtension(path).ToUpperInvariant();
                     byte[] imageBytes = File.ReadAllBytes(path);
-                    ru.AddFile(imageBytes, name, ResourceHelper.TypeName.IMAGE, compress);
+                    ru.AddFile(imageBytes, name, ResourceHelper.TypeName.IMAGE, compress, multithreading);
                     image.Path = "packed:" + name;
                 }
             }
@@ -381,7 +389,7 @@ Other assemblies are packed if marked with Pack=""true"" in the .dna file.
                         }
                         string name = Path.GetFileNameWithoutExtension(path).ToUpperInvariant() + "_" + lastPackIndex++ + Path.GetExtension(path).ToUpperInvariant();
                         byte[] sourceBytes = File.ReadAllBytes(path);
-                        ru.AddFile(sourceBytes, name, ResourceHelper.TypeName.SOURCE, compress);
+                        ru.AddFile(sourceBytes, name, ResourceHelper.TypeName.SOURCE, compress, multithreading);
                         source.Path = "packed:" + name;
                     }
                 }

--- a/Source/ExcelDnaPack/PackProgram.cs
+++ b/Source/ExcelDnaPack/PackProgram.cs
@@ -20,10 +20,10 @@ ExcelDnaPack is a command-line utility to pack ExcelDna add-ins into a single .x
 
 Usage: ExcelDnaPack.exe dnaPath [/O outputPath] [/Y] 
 
-  dnaPath      The path to the primary .dna file for the ExcelDna add-in.
-  /Y           If the output .xll exists, overwrite without prompting.
-  /NC          no compress (LZMA) of resources
-  /O outPath   Output path - default is <dnaPath>-packed.xll.
+  dnaPath         The path to the primary .dna file for the ExcelDna add-in.
+  /Y              If the output .xll exists, overwrite without prompting.
+  /NoCompression  no compress (LZMA) of resources
+  /O outPath      Output path - default is <dnaPath>-packed.xll.
 
 Example: ExcelDnaPack.exe MyAddins\FirstAddin.dna
 		 The packed add-in file will be created as MyAddins\FirstAddin-packed.xll.
@@ -110,7 +110,7 @@ Other assemblies are packed if marked with Pack=""true"" in the .dna file.
                     {
                         overwrite = true;
                     } else
-                    if (args[i].Equals("/NC", StringComparison.CurrentCultureIgnoreCase))
+                    if (args[i].Equals("/NoCompression", StringComparison.CurrentCultureIgnoreCase))
                     {
                         compress = false;
                     }


### PR DESCRIPTION
if you have big projects the packing can take a long time, for testing if packing is working fine the version without LZMA is much faster (like my project 40sec. -> 3sec.)

There is a new commad line parameter /NC -> this means no compression

Signed-off-by: Konrad Mattheis <konrad.mattheis@akquinet.de>