### PR TITLE
Implement packing for localized .resources assemblies

### DIFF
--- a/Package/ExcelDna.AddIn/ExcelDna.AddIn.nuspec
+++ b/Package/ExcelDna.AddIn/ExcelDna.AddIn.nuspec
@@ -25,10 +25,10 @@
     </dependencies>
     </metadata>
     <files>
-        <file src="..\..\DistributionX\ExcelDna.Integration.dll" target="tools\ExcelDna.Integration.dll" />
-        <file src="..\..\DistributionX\ExcelDna.xll" target="tools\ExcelDna.xll" />
-        <file src="..\..\DistributionX\ExcelDna64.xll" target="tools\ExcelDna64.xll" />
-        <file src="..\..\DistributionX\ExcelDnaPack.exe" target="tools\ExcelDnaPack.exe" />
+        <file src="..\..\Distribution\ExcelDna.Integration.dll" target="tools\ExcelDna.Integration.dll" />
+        <file src="..\..\Distribution\ExcelDna.xll" target="tools\ExcelDna.xll" />
+        <file src="..\..\Distribution\ExcelDna64.xll" target="tools\ExcelDna64.xll" />
+        <file src="..\..\Distribution\ExcelDnaPack.exe" target="tools\ExcelDnaPack.exe" />
         <file src="content\ExcelDna-Template.dna" target="content\ExcelDna-Template.dna" />
         <file src="tools\install.ps1" target="tools\install.ps1" />
         <file src="tools\uninstall.ps1" target="tools\uninstall.ps1" />

--- a/Package/ExcelDna.AddIn/ExcelDna.AddIn.nuspec
+++ b/Package/ExcelDna.AddIn/ExcelDna.AddIn.nuspec
@@ -25,10 +25,10 @@
     </dependencies>
     </metadata>
     <files>
-        <file src="..\..\Distribution\ExcelDna.Integration.dll" target="tools\ExcelDna.Integration.dll" />
-        <file src="..\..\Distribution\ExcelDna.xll" target="tools\ExcelDna.xll" />
-        <file src="..\..\Distribution\ExcelDna64.xll" target="tools\ExcelDna64.xll" />
-        <file src="..\..\Distribution\ExcelDnaPack.exe" target="tools\ExcelDnaPack.exe" />
+        <file src="..\..\DistributionX\ExcelDna.Integration.dll" target="tools\ExcelDna.Integration.dll" />
+        <file src="..\..\DistributionX\ExcelDna.xll" target="tools\ExcelDna.xll" />
+        <file src="..\..\DistributionX\ExcelDna64.xll" target="tools\ExcelDna64.xll" />
+        <file src="..\..\DistributionX\ExcelDnaPack.exe" target="tools\ExcelDnaPack.exe" />
         <file src="content\ExcelDna-Template.dna" target="content\ExcelDna-Template.dna" />
         <file src="tools\install.ps1" target="tools\install.ps1" />
         <file src="tools\uninstall.ps1" target="tools\uninstall.ps1" />

--- a/Package/ExcelDna.AddIn/tools/install.ps1
+++ b/Package/ExcelDna.AddIn/tools/install.ps1
@@ -76,7 +76,7 @@ else
 
 Write-Host "`tAdding post-build commands"
 # We'd actually like to put $(SolutionDir)packages\Excel-DNA.0.30.0\tools\ExcelDna.xll
-$solutionPath = [System.IO.Path]::GetDirectoryName($project.DTE.Solution.FullName) + "\"
+$solutionPath = [System.IO.Path]::GetDirectoryName($project.DTE.Solution.FullName)
 # Write-host ("`tSolution Path: " + $solutionPath)
 # Write-host $toolsPath
 $escapedSearch = [regex]::Escape($solutionPath)

--- a/Package/ExcelDna.AddIn/tools/install.ps1
+++ b/Package/ExcelDna.AddIn/tools/install.ps1
@@ -76,7 +76,7 @@ else
 
 Write-Host "`tAdding post-build commands"
 # We'd actually like to put $(SolutionDir)packages\Excel-DNA.0.30.0\tools\ExcelDna.xll
-$solutionPath = [System.IO.Path]::GetDirectoryName($project.DTE.Solution.FullName)
+$solutionPath = [System.IO.Path]::GetDirectoryName($project.DTE.Solution.FullName) + "\"
 # Write-host ("`tSolution Path: " + $solutionPath)
 # Write-host $toolsPath
 $escapedSearch = [regex]::Escape($solutionPath)

--- a/Package/ExcelDna.Integration/ExcelDna.Integration.nuspec
+++ b/Package/ExcelDna.Integration/ExcelDna.Integration.nuspec
@@ -14,7 +14,7 @@
         <tags>excel exceldna udf excel-dna</tags>
     </metadata>
     <files>
-        <file src="..\..\Distribution\ExcelDna.Integration.dll" target="lib\ExcelDna.Integration.dll" />
+        <file src="..\..\DistributionX\ExcelDna.Integration.dll" target="lib\ExcelDna.Integration.dll" />
         <file src="tools\install.ps1" target="tools\install.ps1" />
     </files>
 </package>

--- a/Package/ExcelDna.Integration/ExcelDna.Integration.nuspec
+++ b/Package/ExcelDna.Integration/ExcelDna.Integration.nuspec
@@ -14,7 +14,7 @@
         <tags>excel exceldna udf excel-dna</tags>
     </metadata>
     <files>
-        <file src="..\..\DistributionX\ExcelDna.Integration.dll" target="lib\ExcelDna.Integration.dll" />
+        <file src="..\..\Distribution\ExcelDna.Integration.dll" target="lib\ExcelDna.Integration.dll" />
         <file src="tools\install.ps1" target="tools\install.ps1" />
     </files>
 </package>

--- a/Package/pack.ps1
+++ b/Package/pack.ps1
@@ -4,20 +4,20 @@ $root = $Env:APPVEYOR_BUILD_FOLDER
 if ($Env:PLATFORM -eq "x86")
 {
   Write-Host "Copying 'x86' output to Distribution"
-  Copy-Item -force $root\Source\ExcelDna\Release\ExcelDna.xll $root\DistributionX\ExcelDna.xll
+  Copy-Item -force $root\Source\ExcelDna\Release\ExcelDna.xll $root\Distribution\ExcelDna.xll
 }
 
 if ($Env:PLATFORM -eq "x64")
 {
   Write-Host "Copying 'x64' output to Distribution"
-  Copy-Item -force $root\Source\ExcelDna\Release64\ExcelDna64.xll $root\DistributionX\ExcelDna64.xll
+  Copy-Item -force $root\Source\ExcelDna\Release64\ExcelDna64.xll $root\Distribution\ExcelDna64.xll
 }
 
 if ($Env:PLATFORM -eq "Any CPU")
 {
   Write-Host "Copying 'Any CPU' output to Distribution"
   Copy-Item -force $root\Source\ExcelDna.Integration\bin\Release\ExcelDna.Integration.dll $root\Distribution\ExcelDna.Integration.dll
-  Copy-Item -force $root\Source\ExcelDnaPack\bin\Release\ExcelDnaPack.exe $root\DistributionX\ExcelDnaPack.exe
+  Copy-Item -force $root\Source\ExcelDnaPack\bin\Release\ExcelDnaPack.exe $root\Distribution\ExcelDnaPack.exe
 }
 
 if (($Env:PLATFORM -eq "x64") -and ($Env:CONFIGURATION -eq "Release"))

--- a/Package/pack.ps1
+++ b/Package/pack.ps1
@@ -4,20 +4,20 @@ $root = $Env:APPVEYOR_BUILD_FOLDER
 if ($Env:PLATFORM -eq "x86")
 {
   Write-Host "Copying 'x86' output to Distribution"
-  Copy-Item -force $root\Source\ExcelDna\Release\ExcelDna.xll $root\Distribution\ExcelDna.xll
+  Copy-Item -force $root\Source\ExcelDna\Release\ExcelDna.xll $root\DistributionX\ExcelDna.xll
 }
 
 if ($Env:PLATFORM -eq "x64")
 {
   Write-Host "Copying 'x64' output to Distribution"
-  Copy-Item -force $root\Source\ExcelDna\Release64\ExcelDna64.xll $root\Distribution\ExcelDna64.xll
+  Copy-Item -force $root\Source\ExcelDna\Release64\ExcelDna64.xll $root\DistributionX\ExcelDna64.xll
 }
 
 if ($Env:PLATFORM -eq "Any CPU")
 {
   Write-Host "Copying 'Any CPU' output to Distribution"
   Copy-Item -force $root\Source\ExcelDna.Integration\bin\Release\ExcelDna.Integration.dll $root\Distribution\ExcelDna.Integration.dll
-  Copy-Item -force $root\Source\ExcelDnaPack\bin\Release\ExcelDnaPack.exe $root\Distribution\ExcelDnaPack.exe
+  Copy-Item -force $root\Source\ExcelDnaPack\bin\Release\ExcelDnaPack.exe $root\DistributionX\ExcelDnaPack.exe
 }
 
 if (($Env:PLATFORM -eq "x64") -and ($Env:CONFIGURATION -eq "Release"))

--- a/Package/pack.ps1
+++ b/Package/pack.ps1
@@ -16,7 +16,7 @@ if ($Env:PLATFORM -eq "x64")
 if ($Env:PLATFORM -eq "Any CPU")
 {
   Write-Host "Copying 'Any CPU' output to Distribution"
-  Copy-Item -force $root\Source\ExcelDna.Integration\bin\Release\ExcelDna.Integration.dll $root\DistributionX\ExcelDna.Integration.dll
+  Copy-Item -force $root\Source\ExcelDna.Integration\bin\Release\ExcelDna.Integration.dll $root\Distribution\ExcelDna.Integration.dll
   Copy-Item -force $root\Source\ExcelDnaPack\bin\Release\ExcelDnaPack.exe $root\DistributionX\ExcelDnaPack.exe
 }
 

--- a/Package/pack.ps1
+++ b/Package/pack.ps1
@@ -16,7 +16,7 @@ if ($Env:PLATFORM -eq "x64")
 if ($Env:PLATFORM -eq "Any CPU")
 {
   Write-Host "Copying 'Any CPU' output to Distribution"
-  Copy-Item -force $root\Source\ExcelDna.Integration\bin\Release\ExcelDna.Integration.dll $root\Distribution\ExcelDna.Integration.dll
+  Copy-Item -force $root\Source\ExcelDna.Integration\bin\Release\ExcelDna.Integration.dll $root\DistributionX\ExcelDna.Integration.dll
   Copy-Item -force $root\Source\ExcelDnaPack\bin\Release\ExcelDnaPack.exe $root\DistributionX\ExcelDnaPack.exe
 }
 

--- a/Source/ExcelDna.Integration/ExternalLibrary.cs
+++ b/Source/ExcelDna.Integration/ExternalLibrary.cs
@@ -251,14 +251,15 @@ namespace ExcelDna.Integration
 			}
 		}
         
-        // A copy of this method lives in ExcelDna.Loader - AssemblyManager.cs
+        // Similar copy to this method lives in ExcelDna.Loader - AssemblyManager.cs
+        // But here we don't deal with .resources assemblies
         private static Assembly GetAssemblyIfLoaded(string assemblyName)
         {
             Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
             foreach (Assembly loadedAssembly in assemblies)
             {
-                string loadedAssemblyName = loadedAssembly.FullName.Split(',')[0];
-                if (string.Equals(assemblyName, loadedAssemblyName, StringComparison.OrdinalIgnoreCase))
+                AssemblyName loadedAssemblyName = loadedAssembly.GetName();
+                if (string.Equals(assemblyName, loadedAssemblyName.Name, StringComparison.OrdinalIgnoreCase))
                     return loadedAssembly;
             }
             return null;

--- a/Source/ExcelDna/ExcelDna.rc
+++ b/Source/ExcelDna/ExcelDna.rc
@@ -34,6 +34,7 @@ BEGIN
     "#include ""winresrc.h""\r\0"
 END
 
+LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
 3 TEXTINCLUDE 
 BEGIN
     "#ifdef _DEBUG\r\n"
@@ -44,7 +45,7 @@ BEGIN
     "EXCELDNA.INTEGRATION    ASSEMBLY                ""..\\\\ExcelDna.Integration\\\\bin\\\\Release\\\\ExcelDna.Integration.dll""\r\n"
     "#endif\r\0"
 END
-
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 #endif    // APSTUDIO_INVOKED
 
 
@@ -197,6 +198,7 @@ END
 //
 // Generated from the TEXTINCLUDE 3 resource.
 //
+LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
 #ifdef _DEBUG
 EXCELDNA.LOADER         ASSEMBLY                "..\\ExcelDna.Loader\\bin\\Debug\\ExcelDna.Loader.dll"
 EXCELDNA.INTEGRATION    ASSEMBLY                "..\\ExcelDna.Integration\\bin\\Debug\\ExcelDna.Integration.dll"

--- a/Source/ExcelDnaPack/ResourceHelper.cs
+++ b/Source/ExcelDnaPack/ResourceHelper.cs
@@ -178,7 +178,7 @@ internal unsafe static class ResourceHelper
         {
             lock (lockResource)
             {
-                bool result = ResourceHelper.UpdateResource(_hUpdate, typeName, name, localeEnglishUS, IntPtr.Zero, 0);
+                bool result = ResourceHelper.UpdateResource(_hUpdate, typeName, name, localeNeutral, IntPtr.Zero, 0);
                 if (!result)
                 {
                     throw new Win32Exception();


### PR DESCRIPTION
This is an attempt at a simplified version of the localization support discussed in #35 .
Instead of using the PE file support for adding a culture to a resource, we just append the name of the culture to the packed resource name (and check this when doing the AssemblyResolve).
