### PR TITLE
initialize the LogStrings

### DIFF
--- a/Source/ExcelDna.Integration/LogDisplay.cs
+++ b/Source/ExcelDna.Integration/LogDisplay.cs
@@ -193,7 +193,7 @@ namespace ExcelDna.Logging
 
     public static class LogDisplay
     {
-        internal static List<string> LogStrings;
+        internal static List<string> LogStrings = new List<string>();
         internal static bool LogStringsUpdated;
         const int maxLogSize = 10000;   // Max number of strings we'll allow in the buffer. Individual strings are unbounded.
         internal static object SyncRoot = new object();
@@ -205,7 +205,6 @@ namespace ExcelDna.Logging
         // This must be called on the main Excel thread.
         internal static void CreateInstance()
         {
-            LogStrings = new List<string>();
             LogStringsUpdated = true;
             _syncContext = SynchronizationContext.Current;
             IsFormVisible = false;


### PR DESCRIPTION
It can avoid the NULL exception issue when LogDisplay is configured to be top trace listener. Since it is static, instead of checking the NULL in the function, I create the instance when the class is constructed. So no need NULL check anymore.