### PR TITLE
Fixed the crash bug when xlcFileClose is executed when there are COM Add-Ins loaded (e.g. Reuters Eikon). The changes are immaterial but removes the crash bug

### DIFF
--- a/Source/ExcelDna.Integration/Excel.cs
+++ b/Source/ExcelDna.Integration/Excel.cs
@@ -273,21 +273,15 @@ namespace ExcelDna.Integration
             {
                 XlCall.Excel(XlCall.xlcNew, 5);
                 XlCall.Excel(XlCall.xlcWorkbookInsert, 6);
-                var scratch = (object[,])XlCall.Excel(XlCall.xlfGetWorkbook, 1);
-                var bookName = Regex.Match(scratch[0, 0].ToString(), "\\[[^\\[\\]]+\\]").Value;
-                bookName = bookName.Substring(1, bookName.Length - 2); // trim leading [ and trailing ]
-
+                
                 // Try again
                 application = GetApplicationFromWindows();
+
+                XlCall.Excel(XlCall.xlcFileClose, false);
+
                 if (application == null)
                     // This is really bad - throwing an exception ...
                     throw new InvalidOperationException("Excel Application object could not be retrieved.");
-
-                //Use the COM model to close a book is safer when the COM model is initialised by other COM Add-Ins, e.g.Reuters Eikon
-                //XlCall.Excel(XlCall.xlcFileClose, false);
-                var books = application.GetType().InvokeMember("Workbooks", BindingFlags.GetProperty, null, application, null, _enUsCulture);
-                var book = books.GetType().InvokeMember("Item", BindingFlags.GetProperty, null, books, new object[] { bookName }, _enUsCulture);
-                book.GetType().InvokeMember("Close", BindingFlags.InvokeMethod, null, book, new object[] { false }, _enUsCulture);
             }
             finally
             {

--- a/Source/ExcelDna.Integration/Excel.cs
+++ b/Source/ExcelDna.Integration/Excel.cs
@@ -271,7 +271,6 @@ namespace ExcelDna.Integration
             if (isExcelPre15) XlCall.Excel(XlCall.xlcEcho, false);
             try
             {
-                System.Windows.Forms.MessageBox.Show("insert book", "Test");
                 XlCall.Excel(XlCall.xlcNew, 5);
                 XlCall.Excel(XlCall.xlcWorkbookInsert, 6);
                 var scratch = (object[,])XlCall.Excel(XlCall.xlfGetWorkbook, 1);
@@ -284,15 +283,11 @@ namespace ExcelDna.Integration
                     // This is really bad - throwing an exception ...
                     throw new InvalidOperationException("Excel Application object could not be retrieved.");
 
-                System.Windows.Forms.MessageBox.Show("found app", "Test");
-
                 //Use the COM model to close a book is safer when the COM model is initialised by other COM Add-Ins, e.g.Reuters Eikon
                 //XlCall.Excel(XlCall.xlcFileClose, false);
                 var books = application.GetType().InvokeMember("Workbooks", BindingFlags.GetProperty, null, application, null, _enUsCulture);
                 var book = books.GetType().InvokeMember("Item", BindingFlags.GetProperty, null, books, new object[] { bookName }, _enUsCulture);
                 book.GetType().InvokeMember("Close", BindingFlags.InvokeMethod, null, book, new object[] { false }, _enUsCulture);
-
-                System.Windows.Forms.MessageBox.Show("clise book", "Test");
             }
             finally
             {


### PR DESCRIPTION
Excel.cls file has been updated with the following changes:


GetApplicationFromWindow has been updated to hunt thru all EXCEL7 windows, rather than the first.

GetApplication() has been changed to use COM method Workbook.Close(false) to close the scratch book creaeted.

Tested with many usage cases and confirm the changs above have no consequence other than removing the nasty crash bug when an Excel-DNA is used along side other COM Add-Ins (e.g. Reuters Eikon).