### PR TITLE
add facility for copying external library version to xll version

### DIFF
--- a/Source/ExcelDna.Integration/DnaLibrarySerialization.cs
+++ b/Source/ExcelDna.Integration/DnaLibrarySerialization.cs
@@ -227,6 +227,7 @@ namespace ExcelDna.Serialization
             WriteAttribute(@"LoadFromBytes", @"", System.Xml.XmlConvert.ToString((global::System.Boolean)((global::System.Boolean)o.@LoadFromBytes)));
             WriteAttribute(@"ExplicitExports", @"", System.Xml.XmlConvert.ToString((global::System.Boolean)((global::System.Boolean)o.@ExplicitExports)));
             WriteAttribute(@"ExplicitRegistration", @"", System.Xml.XmlConvert.ToString((global::System.Boolean)((global::System.Boolean)o.@ExplicitRegistration)));
+            WriteAttribute(@"UseVersionAsOutputVersion", @"", System.Xml.XmlConvert.ToString((global::System.Boolean)((global::System.Boolean)o.@UseVersionAsOutputVersion)));
             WriteEndElement(o);
         }
 
@@ -651,7 +652,7 @@ namespace ExcelDna.Serialization
             if (isNull) return null;
             global::ExcelDna.Integration.ExternalLibrary o;
             o = new global::ExcelDna.Integration.ExternalLibrary();
-            bool[] paramsRead = new bool[7];
+            bool[] paramsRead = new bool[8];
             while (Reader.MoveToNextAttribute()) {
                 if (!paramsRead[0] && ((object) Reader.LocalName == (object)id16_Path && (object) Reader.NamespaceURI == (object)id2_Item)) {
                     o.@Path = Reader.Value;
@@ -681,8 +682,12 @@ namespace ExcelDna.Serialization
                     o.@ExplicitRegistration = System.Xml.XmlConvert.ToBoolean(Reader.Value);
                     paramsRead[6] = true;
                 }
+                else if (!paramsRead[7] && ((object) Reader.LocalName == (object)id25_UseVersionAsOutputVersion && (object) Reader.NamespaceURI == (object) id2_Item)) {
+                    o.@UseVersionAsOutputVersion = System.Xml.XmlConvert.ToBoolean(Reader.Value);
+                    paramsRead[7] = true;
+                }
                 else if (!IsXmlnsAttribute(Reader.Name)) {
-                    UnknownNode((object)o, @":Path, :TypeLibPath, :ComServer, :Pack, :LoadFromBytes, :ExplicitExports, :ExplicitRegistration");
+                    UnknownNode((object)o, @":Path, :TypeLibPath, :ComServer, :Pack, :LoadFromBytes, :ExplicitExports, :ExplicitRegistration, :UseVersionAsOutputVersion");
                 }
             }
             Reader.MoveToElement();
@@ -735,6 +740,7 @@ namespace ExcelDna.Serialization
         string id4_RuntimeVersion;
         string id8_CompilerVersion;
         string id21_ComServer;
+        string id25_UseVersionAsOutputVersion;
 
         protected override void InitIDs() {
             id2_Item = Reader.NameTable.Add(@"");
@@ -761,6 +767,7 @@ namespace ExcelDna.Serialization
             id4_RuntimeVersion = Reader.NameTable.Add(@"RuntimeVersion");
             id8_CompilerVersion = Reader.NameTable.Add(@"CompilerVersion");
             id21_ComServer = Reader.NameTable.Add(@"ComServer");
+            id25_UseVersionAsOutputVersion = Reader.NameTable.Add(@"UseVersionAsOutputVersion");
         }
     }
 

--- a/Source/ExcelDna.Integration/ExternalLibrary.cs
+++ b/Source/ExcelDna.Integration/ExternalLibrary.cs
@@ -76,6 +76,14 @@ namespace ExcelDna.Integration
             set { _ExplicitRegistration = value; }
         }
 
+	    private bool _UseVersionAsOutputVersion = false;
+	    [XmlAttribute]
+	    public bool UseVersionAsOutputVersion
+        {
+	        get { return _UseVersionAsOutputVersion; }
+            set { _UseVersionAsOutputVersion = value; }
+	    }
+
 		internal List<ExportedAssembly> GetAssemblies(string pathResolveRoot, DnaLibrary dnaLibrary)
 		{
 			List<ExportedAssembly> list = new List<ExportedAssembly>();

--- a/Source/ExcelDnaPack/PackProgram.cs
+++ b/Source/ExcelDnaPack/PackProgram.cs
@@ -236,11 +236,12 @@ Other assemblies are packed if marked with Pack=""true"" in the .dna file.
             }
 			if (dna.ExternalLibraries != null)
 			{
+			    bool copiedVersion = false;
 				foreach (ExternalLibrary ext in dna.ExternalLibraries)
 				{
+				    string path = dna.ResolvePath(ext.Path);
 					if (ext.Pack)
 					{
-						string path = dna.ResolvePath(ext.Path);
                         Console.WriteLine("  ~~> ExternalLibrary path {0} resolved to {1}.", ext.Path, path);
 						if (Path.GetExtension(path).Equals(".DNA", StringComparison.OrdinalIgnoreCase))
 						{
@@ -292,7 +293,23 @@ Other assemblies are packed if marked with Pack=""true"" in the .dna file.
                             }
                         }
 					}
-                    
+				    if (ext.UseVersionAsOutputVersion)
+				    {
+				        if (copiedVersion)
+				        {
+				            Console.WriteLine("  ~~> Assembly version already copied from previous ExternalLibrary; ignoring 'UseVersionAsOutputVersion' attribute.");
+				            continue;
+				        }
+				        try
+				        {
+				            ru.CopyFileVersion(path);
+				            copiedVersion = true;
+				        }
+				        catch (Exception e)
+				        {
+				            Console.WriteLine("  ~~> Error copying version to output version: {0}", e.Message);
+				        }
+				    }
 				}
 			}
 			// Collect the list of all the references.


### PR DESCRIPTION
I had a similar problem to this: https://groups.google.com/forum/#!topic/exceldna/HlVeZUZNcqM Basically, I wanted the .xll generated by ExcelDnaPack to have a version number other than the one from the template .xll. VerPatch (linked from that discussion) worked, but actually figuring out how to integrate it into my workflow was tricky. Patching ExcelDnaPack turned out to be easier.

You can now mark ExternalLibrary elements in the .dna file with UseVersionAsOutputVersion="true" to copy their version resource into the output .xll. If you specify this for more than one ExternalLibrary only the first will be used, and a warning will be emitted. If the version copying fails for some reason (like the source file doesn't have it, e.g. if it's a .dna file), then a warning is emitted.

This seemed like the most straightforward way to do this, but I'm totally open to suggestions for refinements or things I've missed.