### PR TITLE
Make sure ExcelDna build targets run before Post-build event. Fixes #120

### DIFF
--- a/Package/ExcelDna.AddIn/tools/ExcelDna.AddIn.targets
+++ b/Package/ExcelDna.AddIn/tools/ExcelDna.AddIn.targets
@@ -16,14 +16,14 @@
   </PropertyGroup>
 
   <!--
-    Extend the AfterBuild target to call our ExcelDnaBuild target
+    Extend the PostBuild target to call our ExcelDnaBuild and ExcelDnaPack targets
   -->
   <PropertyGroup>
-    <BuildDependsOn>
-      $(BuildDependsOn);
+    <PostBuildEventDependsOn>
+      $(PostBuildEventDependsOn);
       ExcelDnaBuild;
       ExcelDnaPack;
-    </BuildDependsOn>
+    </PostBuildEventDependsOn>
   </PropertyGroup>
 
   <!--

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget.sln
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SingleDnaFileInSubFolderDef
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SingleDnaFileNoConfigDefaultSuffix", "SingleDnaFileNoConfigDefaultSuffix\SingleDnaFileNoConfigDefaultSuffix.csproj", "{34B3D54A-3D96-4754-BBED-B9DE164BAA80}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PreAndPostBuildEvents", "PreAndPostBuildEvents\PreAndPostBuildEvents.csproj", "{01805002-4F09-432A-B1E2-803C273671CB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,10 @@ Global
 		{34B3D54A-3D96-4754-BBED-B9DE164BAA80}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{34B3D54A-3D96-4754-BBED-B9DE164BAA80}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{34B3D54A-3D96-4754-BBED-B9DE164BAA80}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01805002-4F09-432A-B1E2-803C273671CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01805002-4F09-432A-B1E2-803C273671CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01805002-4F09-432A-B1E2-803C273671CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01805002-4F09-432A-B1E2-803C273671CB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/PreAndPostBuildEvents/AddIn.cs
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/PreAndPostBuildEvents/AddIn.cs
@@ -1,0 +1,21 @@
+﻿using System.IO;
+using System.Windows.Forms;
+using ExcelDna.Integration;
+
+namespace PreAndPostBuildEvents
+{
+    public class AddIn : IExcelAddIn
+    {
+        public void AutoOpen()
+        {
+            var thisAddInName = Path.GetFileName((string)XlCall.Excel(XlCall.xlGetName));
+            var message = string.Format("Excel-DNA Add-In '{0}' loaded!", thisAddInName);
+
+            MessageBox.Show(message, thisAddInName, MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+
+        public void AutoClose()
+        {
+        }
+    }
+}

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/PreAndPostBuildEvents/MyLibrary-AddIn.dna
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/PreAndPostBuildEvents/MyLibrary-AddIn.dna
@@ -1,0 +1,20 @@
+<DnaLibrary Name="PreAndPostBuildEvents Add-In" RuntimeVersion="v4.0">
+  <ExternalLibrary Path="PreAndPostBuildEvents.dll" LoadFromBytes="true" Pack="true" />
+  
+  <!-- 
+       The RuntimeVersion attribute above allows two settings:
+       * RuntimeVersion="v2.0" - for .NET 2.0, 3.0 and 3.5
+       * RuntimeVersion="v4.0" - for .NET 4 and 4.5
+
+       Additional referenced assemblies can be specified by adding 'Reference' tags. 
+       These libraries will not be examined and registered with Excel as add-in libraries, 
+       but will be packed into the -packed.xll file and loaded at runtime as needed.
+       For example:
+       
+       <Reference Path="Another.Library.dll" Pack="true" />
+  
+       Excel-DNA also allows the xml for ribbon UI extensions to be specified in the .dna file.
+       See the main Excel-DNA site at http://excel-dna.net for downloads of the full distribution.
+  -->
+
+</DnaLibrary>

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/PreAndPostBuildEvents/PreAndPostBuildEvents.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/PreAndPostBuildEvents/PreAndPostBuildEvents.csproj
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{01805002-4F09-432A-B1E2-803C273671CB}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>PreAndPostBuildEvents</RootNamespace>
+    <AssemblyName>PreAndPostBuildEvents</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="ExcelDna.Integration">
+      <HintPath>..\..\.exceldna.addin\tools\ExcelDna.Integration.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AddIn.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="MyLibrary-AddIn.dna">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(ProjectDir)..\..\.exceldna.addin\tools\ExcelDna.AddIn.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>ECHO Running ExcelDna **Pre-build** event</PreBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PostBuildEvent>ECHO Running ExcelDna **Post-build** event</PostBuildEvent>
+  </PropertyGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/PreAndPostBuildEvents/Properties/AssemblyInfo.cs
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/PreAndPostBuildEvents/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("PreAndPostBuildEvents")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("PreAndPostBuildEvents")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("01805002-4f09-432a-b1e2-803c273671cb")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests/ExcelDna.AddIn.Tasks.IntegrationTests.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests/ExcelDna.AddIn.Tasks.IntegrationTests.csproj
@@ -46,6 +46,7 @@
     <Compile Include="SeparateDnaFilesCustomSuffix_x86_x64IntegrationTests.cs" />
     <Compile Include="SeparateDnaFilesDefaultSuffixIntegrationTests.cs" />
     <Compile Include="MsBuildParametersOverrideTests.cs" />
+    <Compile Include="PreAndPostBuildEventsIntegrationTests.cs" />
     <Compile Include="SingleDnaFileNoConfigDefaultSuffixIntegrationTests.cs" />
     <Compile Include="SingleDnaFileDefaultSuffixSubFolderTests.cs" />
     <Compile Include="Utils\SilentProcessRunner.cs" />

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests/PreAndPostBuildEventsIntegrationTests.cs
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests/PreAndPostBuildEventsIntegrationTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace ExcelDna.AddIn.Tasks.IntegrationTests
+{
+    [TestFixture]
+    public class PreAndPostBuildEventsIntegrationTests : IntegrationTestBase
+    {
+        [Test]
+        public void ExcelDna_build_targets_run_after_the_Pre_build_event_and_before_the_Post_build_event()
+        {
+            const string projectBasePath = @"PreAndPostBuildEvents\";
+            const string projectOutDir = projectBasePath + @"bin\Release\";
+
+            Clean(projectOutDir);
+
+            MsBuild(projectBasePath + "PreAndPostBuildEvents.csproj /t:Build /p:Configuration=Release /v:m " + MsBuildParam("OutputPath", @"bin\Release\"),
+                buildOutput =>
+                {
+                    var preBuildEventIndex = buildOutput.IndexOf("Running ExcelDna **Pre-build** event", StringComparison.InvariantCulture);
+                    var excelDnaBuildEvent = buildOutput.IndexOf("ExcelDnaBuild:", StringComparison.InvariantCulture);
+                    var excelDnaPackEvent = buildOutput.IndexOf("ExcelDnaPack:", StringComparison.InvariantCulture);
+                    var postBuildEventIndex = buildOutput.IndexOf("Running ExcelDna **Post-build** event", StringComparison.InvariantCulture);
+
+                    Assert.That(preBuildEventIndex, Is.GreaterThanOrEqualTo(0), "Pre-build event did not execute as expected");
+                    Assert.That(excelDnaBuildEvent, Is.GreaterThanOrEqualTo(0), "ExcelDnaBuild target did not execute as expected");
+                    Assert.That(excelDnaPackEvent, Is.GreaterThanOrEqualTo(0), "ExcelDnaPack target did not execute as expected");
+                    Assert.That(postBuildEventIndex, Is.GreaterThanOrEqualTo(0), "Post-build event did not execute as expected");
+
+                    Assert.That(preBuildEventIndex, Is.LessThan(excelDnaBuildEvent), "Pre-build event executed after ExcelDnaBuild target");
+                    Assert.That(excelDnaBuildEvent, Is.LessThan(excelDnaPackEvent), "ExcelDnaBuild target executed after the ExcelDnaPack target");
+                    Assert.That(excelDnaPackEvent, Is.LessThan(postBuildEventIndex), "ExcelDnaPack target executed after the Post-build event");
+                });
+        }
+    }
+}


### PR DESCRIPTION
Here is a fix for issue #120. Here we're extending the `PostBuild`target, so that our build process runs before the Post-build event, but after the Pre-build event, thus running exactly in the middle, as expected.

i.e. The sequence is what you'd expect:
* **Pre-build event**
* ExcelDna Build
* ExcelDna Pack
* **Post-build event**

I've added an integration test to prove that it works, and to help us catch any regressions to this behavior in the future.

Here is an example output of the integration test:

    Microsoft (R) Build Engine version 14.0.25420.1
    Copyright (C) Microsoft Corporation. All rights reserved.
    
      Running ExcelDna **Pre-build** event
      PreAndPostBuildEvents -> C:\dev\caioproiete\ExcelDna\Source\Tests\ExcelDna.AddIn.Tasks.IntegrationTe    sts.TestTarget\PreAndPostBuildEvents\bin\Release\PreAndPostBuildEvents.dll
      ---
      ExcelDnaBuild: MyLibrary-AddIn.dna -> bin\Release\MyLibrary-AddIn.dna
      ExcelDnaBuild: ..\..\.exceldna.addin\tools\ExcelDna.xll -> bin\Release\MyLibrary-AddIn.xll
      ExcelDnaBuild: ---
      ExcelDnaBuild: MyLibrary-AddIn.dna -> bin\Release\MyLibrary-AddIn64.dna
      ExcelDnaBuild: ..\..\.exceldna.addin\tools\ExcelDna64.xll -> bin\Release\MyLibrary-AddIn64.xll
      ---
      ExcelDnaPack: bin\Release\MyLibrary-AddIn.dna -> bin\Release\MyLibrary-AddIn-packed.xll
      Using base add-in bin\Release\MyLibrary-AddIn.xll
        ~~> ExternalLibrary path PreAndPostBuildEvents.dll resolved to     bin\Release\PreAndPostBuildEvents.dll.
        ->  Updating resource: Type: DNA, Name: __MAIN__, Length: 475
        ->  Updating resource: Type: ASSEMBLY_LZMA, Name: PREANDPOSTBUILDEVENTS, Length: 1767
        ->  Updating resource: Type: ASSEMBLY_LZMA, Name: EXCELDNA.INTEGRATION, Length: 65719
      Completed Packing bin\Release\MyLibrary-AddIn-packed.xll.
      ExcelDnaPack: bin\Release\MyLibrary-AddIn64.dna -> bin\Release\MyLibrary-AddIn64-packed.xll
      Using base add-in bin\Release\MyLibrary-AddIn64.xll
        ~~> ExternalLibrary path PreAndPostBuildEvents.dll resolved to     bin\Release\PreAndPostBuildEvents.dll.
        ->  Updating resource: Type: DNA, Name: __MAIN__, Length: 475
        ->  Updating resource: Type: ASSEMBLY_LZMA, Name: PREANDPOSTBUILDEVENTS, Length: 1767
        ->  Updating resource: Type: ASSEMBLY_LZMA, Name: EXCELDNA.INTEGRATION, Length: 65719
      Completed Packing bin\Release\MyLibrary-AddIn64-packed.xll.
      Running ExcelDna **Post-build** event
