### PR TITLE
ExcelDnaPhysicalFileSystem: Skip FileInfo instance if not overriding the file

### DIFF
--- a/Source/ExcelDna.AddIn.Tasks/Utils/ExcelDnaPhysicalFileSystem.cs
+++ b/Source/ExcelDna.AddIn.Tasks/Utils/ExcelDnaPhysicalFileSystem.cs
@@ -22,10 +22,13 @@ namespace ExcelDna.AddIn.Tasks.Utils
 
         public void CopyFile(string sourceFileName, string destFileName, bool overwrite)
         {
-            var fileInfo = new FileInfo(destFileName);
-            if (overwrite && fileInfo.Exists && fileInfo.IsReadOnly)
+            if (overwrite)
             {
-                fileInfo.IsReadOnly = false;
+                var fileInfo = new FileInfo(destFileName);
+                if (fileInfo.Exists && fileInfo.IsReadOnly)
+                {
+                    fileInfo.IsReadOnly = false;
+                }
             }
 
             File.Copy(sourceFileName, destFileName, overwrite);


### PR DESCRIPTION
Tiny optimization on `ExcelDnaPhysicalFileSystem` to skip creating a `FileInfo` instance if we're not overriding the file being copied