### PR TITLE
Change to build clean task

### DIFF
--- a/Package/ExcelDna.AddIn/tools/ExcelDna.AddIn.targets
+++ b/Package/ExcelDna.AddIn/tools/ExcelDna.AddIn.targets
@@ -1,5 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <UsingTask TaskName="ExcelDna.AddIn.Tasks.CreateExcelAddIn" AssemblyFile="ExcelDna.AddIn.Tasks.dll" />
+  <UsingTask TaskName="ExcelDna.AddIn.Tasks.CleanExcelAddIn" AssemblyFile="ExcelDna.AddIn.Tasks.dll" />
 
   <PropertyGroup>
     <ExcelDnaTargetsImported>true</ExcelDnaTargetsImported>
@@ -14,7 +15,7 @@
       ExcelDnaClean;
     </CleanDependsOn>
   </PropertyGroup>
-
+ 
   <!--
     Extend the PostBuild target to call our ExcelDnaBuild and ExcelDnaPack targets
   -->
@@ -58,16 +59,30 @@
   </PropertyGroup>
 
   <!--
-    Target that removes all .dna, .xll, and .xll.config from the build output folder
+    Target that removes .dna, .xll, and .xll.config from the build output folder
   -->
   <Target Name="ExcelDnaClean" Condition="$(RunExcelDnaClean)">
+    <Message Text="---" Importance="High" />
+
+    <Error Text="ExcelDna32BitAddInSuffix and ExcelDna64BitAddInSuffix cannot be identical. Fix your ExcelDna.Build.props file"
+              Condition="'$(ExcelDna32BitAddInSuffix)' == '$(ExcelDna64BitAddInSuffix)'" />
+    
     <ItemGroup>
-      <ExcelDnaFilesToDelete Include="$(TargetDir)**\*.dna" />
-      <ExcelDnaFilesToDelete Include="$(TargetDir)**\*.xll" />
-      <ExcelDnaFilesToDelete Include="$(TargetDir)**\*.xll.config" />
+      <ExcelDnaFilesInProject Include="@(None)" />
+      <ExcelDnaFilesInProject Include="@(Content)" />
     </ItemGroup>
 
-    <Delete Files="@(ExcelDnaFilesToDelete)"/>
+    <CleanExcelAddIn
+      FilesInProject="@(ExcelDnaFilesInProject)"
+      OutDirectory="$(OutDir)"
+      Xll32FilePath="$(ExcelDnaToolsPath)ExcelDna.xll"
+      Xll64FilePath="$(ExcelDnaToolsPath)ExcelDna64.xll"
+      FileSuffix32Bit="$(ExcelDna32BitAddInSuffix)"
+      FileSuffix64Bit="$(ExcelDna64BitAddInSuffix)"
+      PackIsEnabled="$(RunExcelDnaPack)"
+      PackedFileSuffix="$(ExcelDnaPackXllSuffix)">
+    </CleanExcelAddIn>
+
   </Target>
 
   <!--

--- a/Source/ExcelDna.AddIn.Tasks/CleanExcelAddIn.cs
+++ b/Source/ExcelDna.AddIn.Tasks/CleanExcelAddIn.cs
@@ -1,0 +1,185 @@
+﻿using System;
+using System.Collections;
+using System.IO;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Build.Framework;
+using ExcelDna.AddIn.Tasks.Utils;
+using Microsoft.Build.Utilities;
+
+namespace ExcelDna.AddIn.Tasks
+{
+    public class CleanExcelAddIn : AbstractTask
+    {
+        private readonly IExcelDnaFileSystem _fileSystem;
+        private ITaskItem[] _configFilesInProject;
+        private List<ITaskItem> _packedFilesToDelete;
+        private BuildTaskCommon common;
+
+        public CleanExcelAddIn()
+            : this(new ExcelDnaPhysicalFileSystem())
+        {
+        }
+
+        public CleanExcelAddIn(IExcelDnaFileSystem fileSystem)
+        {
+            if (fileSystem == null)
+            {
+                throw new ArgumentNullException("fileSystem");
+            }
+
+            _fileSystem = fileSystem;
+        }
+
+        public override bool Execute()
+        {
+            try
+            {
+                LogDiagnostics();
+
+                FilesInProject = FilesInProject ?? new ITaskItem[0];
+                LogMessage("Number of files in project: " + FilesInProject.Length, MessageImportance.Low);
+
+                common = new BuildTaskCommon(FilesInProject, OutDirectory, FileSuffix32Bit, FileSuffix64Bit);
+
+                var existingBuiltFiles = common.GetBuildItemsForDnaFiles();
+                _packedFilesToDelete = GetPackedFilesToDelete(existingBuiltFiles);
+
+                LogMessage("---");
+
+                //Get the packed name versions : Refactor this + build items
+                DeleteAddInFiles(existingBuiltFiles);
+                DeletePackedAddInFiles(_packedFilesToDelete);
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                LogError("DNA" + ex.GetType().Name.GetHashCode(), ex.Message);
+                LogError("DNA" + ex.GetType().Name.GetHashCode(), ex.ToString());
+                return false;
+            }
+        }
+
+        private void LogDiagnostics()
+        {
+            LogMessage("----Arguments----", MessageImportance.Low);
+            LogMessage("FilesInProject: " + (FilesInProject ?? new ITaskItem[0]).Length, MessageImportance.Low);
+            LogMessage("OutDirectory: " + OutDirectory, MessageImportance.Low);
+            LogMessage("Xll32FilePath: " + Xll32FilePath, MessageImportance.Low);
+            LogMessage("Xll64FilePath: " + Xll64FilePath, MessageImportance.Low);
+            LogMessage("FileSuffix32Bit: " + FileSuffix32Bit, MessageImportance.Low);
+            LogMessage("FileSuffix64Bit: " + FileSuffix64Bit, MessageImportance.Low);
+            LogMessage("-----------------", MessageImportance.Low);
+        }
+
+        private List<ITaskItem>  GetPackedFilesToDelete(BuildItemSpec[] existingBuiltFiles)
+        {
+            var _packedFilesToDelete = new List<ITaskItem>();
+
+            foreach (var item in existingBuiltFiles)
+            {
+                _packedFilesToDelete.Add(GetPackedFileNames(item.OutputDnaFileNameAs32Bit, item.OutputXllFileNameAs32Bit, item.OutputConfigFileNameAs32Bit));
+                _packedFilesToDelete.Add(GetPackedFileNames(item.OutputDnaFileNameAs64Bit, item.OutputXllFileNameAs64Bit, item.OutputConfigFileNameAs64Bit));
+            }
+
+            return _packedFilesToDelete;
+        }
+
+        private TaskItem GetPackedFileNames(string outputDnaFileName, string outputXllFileName, string outputXllConfigFileName)
+        {
+            var outputPackedDnaFileName = !string.IsNullOrWhiteSpace(PackedFileSuffix)
+            ? Path.Combine(Path.GetDirectoryName(outputDnaFileName) ?? string.Empty,
+                Path.GetFileNameWithoutExtension(outputDnaFileName) + PackedFileSuffix + ".dna")
+            : outputDnaFileName;
+
+            var outputPackedXllFileName = !string.IsNullOrWhiteSpace(PackedFileSuffix)
+              ? Path.Combine(Path.GetDirectoryName(outputXllFileName) ?? string.Empty,
+                  Path.GetFileNameWithoutExtension(outputXllFileName) + PackedFileSuffix + ".xll")
+              : outputXllFileName;
+
+            var outputPackedXllConfigFileName = !string.IsNullOrWhiteSpace(PackedFileSuffix)
+            ? Path.Combine(Path.GetDirectoryName(outputXllFileName) ?? string.Empty,
+                Path.GetFileNameWithoutExtension(outputXllFileName) + PackedFileSuffix + ".xll.config")
+            : outputXllConfigFileName;
+
+            var metadata = new Hashtable
+            {
+                {"OutputPackedDnaFileName", outputPackedDnaFileName},
+                {"OutputPackedXllFileName", outputPackedXllFileName},
+                {"OutputPackedXllConfigFileName", outputPackedXllConfigFileName },
+            };
+
+            return new TaskItem(outputDnaFileName, metadata);
+        }
+
+        private void DeleteAddInFiles(BuildItemSpec[] buildItemsForDnaFiles)
+        {
+            foreach (var item in buildItemsForDnaFiles)
+            {
+                _fileSystem.DeleteFile(item.OutputDnaFileNameAs32Bit);
+                _fileSystem.DeleteFile(item.OutputDnaFileNameAs64Bit);
+
+                _fileSystem.DeleteFile(item.OutputXllFileNameAs32Bit);
+                _fileSystem.DeleteFile(item.OutputXllFileNameAs64Bit);
+
+                _fileSystem.DeleteFile(item.OutputConfigFileNameAs32Bit);
+                _fileSystem.DeleteFile(item.OutputConfigFileNameAs64Bit);
+            }
+        }
+
+        private void DeletePackedAddInFiles(List<ITaskItem> filesToDelete)
+        {
+            filesToDelete.ToList().ForEach(f =>
+            {
+                _fileSystem.DeleteFile(f.GetMetadata("OutputPackedDnaFileName"));
+                _fileSystem.DeleteFile(f.GetMetadata("OutputPackedXllFileName"));
+                _fileSystem.DeleteFile(f.GetMetadata("OutputPackedXllConfigFileName"));
+            });
+        }
+
+        /// <summary>
+        /// The list of files in the project marked as Content or None
+        /// </summary>
+        [Required]
+        public ITaskItem[] FilesInProject { get; set; }
+
+        /// <summary>
+        /// The directory in which the built files were written to
+        /// </summary>
+        [Required]
+        public string OutDirectory { get; set; }
+
+        /// <summary>
+        /// The 32-bit .xll file path; set to <code>$(MSBuildThisFileDirectory)\ExcelDna.xll</code> by default
+        /// </summary>
+        [Required]
+        public string Xll32FilePath { get; set; }
+
+        /// <summary>
+        /// The 64-bit .xll file path; set to <code>$(MSBuildThisFileDirectory)\ExcelDna64.xll</code> by default
+        /// </summary>
+        [Required]
+        public string Xll64FilePath { get; set; }
+
+        /// <summary>
+        /// The name suffix for 32-bit .dna files
+        /// </summary>
+        public string FileSuffix32Bit { get; set; }
+
+        /// <summary>
+        /// The name suffix for 64-bit .dna files
+        /// </summary>
+        public string FileSuffix64Bit { get; set; }
+
+        /// <summary>
+        /// Enable/disable running ExcelDnaPack for .dna files
+        /// </summary>
+        public bool PackIsEnabled { get; set; }
+
+        /// <summary>
+        /// Enable/disable running ExcelDnaPack for .dna files
+        /// </summary>
+        public string PackedFileSuffix { get; set; }
+    }
+}

--- a/Source/ExcelDna.AddIn.Tasks/Common.cs
+++ b/Source/ExcelDna.AddIn.Tasks/Common.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+
+namespace ExcelDna.AddIn.Tasks
+{
+    public class BuildTaskCommon
+    {
+        private string OutDirectory;
+        private string FileSuffix32Bit;
+        private string FileSuffix64Bit;
+        private ITaskItem[] FilesInProject;
+
+        public BuildTaskCommon(ITaskItem[] FilesInProject, string OutDirectory, string FileSuffix32Bit, string FileSuffix64Bit)
+        {
+            this.FilesInProject = FilesInProject;
+            this.OutDirectory = OutDirectory;
+            this.FileSuffix32Bit = FileSuffix32Bit;
+            this.FileSuffix64Bit = FileSuffix64Bit;
+        }
+        
+        internal BuildItemSpec[] GetBuildItemsForDnaFiles()
+        {
+            var buildItemsForDnaFiles = (
+                from item in FilesInProject
+                where string.Equals(Path.GetExtension(item.ItemSpec), ".dna", StringComparison.OrdinalIgnoreCase)
+                orderby item.ItemSpec
+                let inputDnaFileNameAs32Bit = GetDnaFileNameAs32Bit(item.ItemSpec)
+                let inputDnaFileNameAs64Bit = GetDnaFileNameAs64Bit(item.ItemSpec)
+                select new BuildItemSpec
+                {
+                    InputDnaFileName = item.ItemSpec,
+
+                    InputDnaFileNameAs32Bit = inputDnaFileNameAs32Bit,
+                    InputDnaFileNameAs64Bit = inputDnaFileNameAs64Bit,
+
+                    InputConfigFileNameAs32Bit = Path.ChangeExtension(inputDnaFileNameAs32Bit, ".config"),
+                    InputConfigFileNameFallbackAs32Bit = GetAppConfigFileNameAs32Bit(),
+
+                    InputConfigFileNameAs64Bit = Path.ChangeExtension(inputDnaFileNameAs64Bit, ".config"),
+                    InputConfigFileNameFallbackAs64Bit = GetAppConfigFileNameAs64Bit(),
+
+                    OutputDnaFileNameAs32Bit = Path.Combine(OutDirectory, inputDnaFileNameAs32Bit),
+                    OutputDnaFileNameAs64Bit = Path.Combine(OutDirectory, inputDnaFileNameAs64Bit),
+
+                    OutputXllFileNameAs32Bit = Path.Combine(OutDirectory, Path.ChangeExtension(inputDnaFileNameAs32Bit, ".xll")),
+                    OutputXllFileNameAs64Bit = Path.Combine(OutDirectory, Path.ChangeExtension(inputDnaFileNameAs64Bit, ".xll")),
+
+                    OutputConfigFileNameAs32Bit = Path.Combine(OutDirectory, Path.ChangeExtension(inputDnaFileNameAs32Bit, ".xll.config")),
+                    OutputConfigFileNameAs64Bit = Path.Combine(OutDirectory, Path.ChangeExtension(inputDnaFileNameAs64Bit, ".xll.config")),
+                }).ToArray();
+
+            return buildItemsForDnaFiles;
+        }
+
+        private string GetDnaFileNameAs32Bit(string fileName)
+        {
+            return GetFileNameWithBitnessSuffix(fileName, FileSuffix32Bit);
+        }
+
+        private string GetDnaFileNameAs64Bit(string fileName)
+        {
+            return GetFileNameWithBitnessSuffix(fileName, FileSuffix64Bit);
+        }
+
+        private string GetAppConfigFileNameAs32Bit()
+        {
+            return GetFileNameWithBitnessSuffix("App.config", FileSuffix32Bit);
+        }
+
+        private string GetAppConfigFileNameAs64Bit()
+        {
+            return GetFileNameWithBitnessSuffix("App.config", FileSuffix64Bit);
+        }
+
+        private string GetFileNameWithBitnessSuffix(string fileName, string suffix)
+        {
+            var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileName) ?? string.Empty;
+
+            if (!string.IsNullOrWhiteSpace(FileSuffix32Bit))
+            {
+                var indexOfSuffix = fileNameWithoutExtension.LastIndexOf(FileSuffix32Bit, StringComparison.OrdinalIgnoreCase);
+                if (indexOfSuffix > 0)
+                {
+                    fileNameWithoutExtension = fileNameWithoutExtension.Remove(indexOfSuffix);
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(FileSuffix64Bit))
+            {
+                var indexOfSuffix = fileNameWithoutExtension.LastIndexOf(FileSuffix64Bit, StringComparison.OrdinalIgnoreCase);
+                if (indexOfSuffix > 0)
+                {
+                    fileNameWithoutExtension = fileNameWithoutExtension.Remove(indexOfSuffix);
+                }
+            }
+
+            var extension = Path.GetExtension(fileName);
+
+            return Path.Combine(Path.GetDirectoryName(fileName) ?? string.Empty, fileNameWithoutExtension + suffix + extension);
+        }
+    }
+}

--- a/Source/ExcelDna.AddIn.Tasks/CreateExcelAddIn.cs
+++ b/Source/ExcelDna.AddIn.Tasks/CreateExcelAddIn.cs
@@ -14,6 +14,7 @@ namespace ExcelDna.AddIn.Tasks
         private readonly IExcelDnaFileSystem _fileSystem;
         private ITaskItem[] _configFilesInProject;
         private List<ITaskItem> _dnaFilesToPack;
+        private BuildTaskCommon common;
 
         public CreateExcelAddIn()
             : this(new ExcelDnaPhysicalFileSystem())
@@ -45,8 +46,9 @@ namespace ExcelDna.AddIn.Tasks
                 LogMessage("Number of files in project: " + FilesInProject.Length, MessageImportance.Low);
 
                 _configFilesInProject = GetConfigFilesInProject();
+                common = new BuildTaskCommon(FilesInProject, OutDirectory, FileSuffix32Bit, FileSuffix64Bit);
 
-                var buildItemsForDnaFiles = GetBuildItemsForDnaFiles();
+                var buildItemsForDnaFiles = common.GetBuildItemsForDnaFiles();
 
                 TryBuildAddInFor32Bit(buildItemsForDnaFiles);
 
@@ -108,40 +110,6 @@ namespace ExcelDna.AddIn.Tasks
             return configFilesInProject;
         }
 
-        private BuildItemSpec[] GetBuildItemsForDnaFiles()
-        {
-            var buildItemsForDnaFiles = (
-                from item in FilesInProject
-                where string.Equals(Path.GetExtension(item.ItemSpec), ".dna", StringComparison.OrdinalIgnoreCase)
-                orderby item.ItemSpec
-                let inputDnaFileNameAs32Bit = GetDnaFileNameAs32Bit(item.ItemSpec)
-                let inputDnaFileNameAs64Bit = GetDnaFileNameAs64Bit(item.ItemSpec)
-                select new BuildItemSpec
-                {
-                    InputDnaFileName = item.ItemSpec,
-
-                    InputDnaFileNameAs32Bit = inputDnaFileNameAs32Bit,
-                    InputDnaFileNameAs64Bit = inputDnaFileNameAs64Bit,
-
-                    InputConfigFileNameAs32Bit = Path.ChangeExtension(inputDnaFileNameAs32Bit, ".config"),
-                    InputConfigFileNameFallbackAs32Bit = GetAppConfigFileNameAs32Bit(),
-
-                    InputConfigFileNameAs64Bit = Path.ChangeExtension(inputDnaFileNameAs64Bit, ".config"),
-                    InputConfigFileNameFallbackAs64Bit = GetAppConfigFileNameAs64Bit(),
-
-                    OutputDnaFileNameAs32Bit = Path.Combine(OutDirectory, inputDnaFileNameAs32Bit),
-                    OutputDnaFileNameAs64Bit = Path.Combine(OutDirectory, inputDnaFileNameAs64Bit),
-
-                    OutputXllFileNameAs32Bit = Path.Combine(OutDirectory, Path.ChangeExtension(inputDnaFileNameAs32Bit, ".xll")),
-                    OutputXllFileNameAs64Bit = Path.Combine(OutDirectory, Path.ChangeExtension(inputDnaFileNameAs64Bit, ".xll")),
-
-                    OutputConfigFileNameAs32Bit = Path.Combine(OutDirectory, Path.ChangeExtension(inputDnaFileNameAs32Bit, ".xll.config")),
-                    OutputConfigFileNameAs64Bit = Path.Combine(OutDirectory, Path.ChangeExtension(inputDnaFileNameAs64Bit, ".xll.config")),
-                }).ToArray();
-
-            return buildItemsForDnaFiles;
-        }
-
         private void TryBuildAddInFor32Bit(BuildItemSpec[] buildItemsForDnaFiles)
         {
             foreach (var item in buildItemsForDnaFiles)
@@ -180,53 +148,6 @@ namespace ExcelDna.AddIn.Tasks
                     AddDnaToListOfFilesToPack(item.OutputDnaFileNameAs64Bit, item.OutputXllFileNameAs64Bit, item.OutputConfigFileNameAs64Bit);
                 }
             }
-        }
-
-        private string GetDnaFileNameAs32Bit(string fileName)
-        {
-            return GetFileNameWithBitnessSuffix(fileName, FileSuffix32Bit);
-        }
-
-        private string GetDnaFileNameAs64Bit(string fileName)
-        {
-            return GetFileNameWithBitnessSuffix(fileName, FileSuffix64Bit);
-        }
-
-        private string GetAppConfigFileNameAs32Bit()
-        {
-            return GetFileNameWithBitnessSuffix("App.config", FileSuffix32Bit);
-        }
-
-        private string GetAppConfigFileNameAs64Bit()
-        {
-            return GetFileNameWithBitnessSuffix("App.config", FileSuffix64Bit);
-        }
-
-        private string GetFileNameWithBitnessSuffix(string fileName, string suffix)
-        {
-            var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileName) ?? string.Empty;
-
-            if (!string.IsNullOrWhiteSpace(FileSuffix32Bit))
-            {
-                var indexOfSuffix = fileNameWithoutExtension.LastIndexOf(FileSuffix32Bit, StringComparison.OrdinalIgnoreCase);
-                if (indexOfSuffix > 0)
-                {
-                    fileNameWithoutExtension = fileNameWithoutExtension.Remove(indexOfSuffix);
-                }
-            }
-
-            if (!string.IsNullOrWhiteSpace(FileSuffix64Bit))
-            {
-                var indexOfSuffix = fileNameWithoutExtension.LastIndexOf(FileSuffix64Bit, StringComparison.OrdinalIgnoreCase);
-                if (indexOfSuffix > 0)
-                {
-                    fileNameWithoutExtension = fileNameWithoutExtension.Remove(indexOfSuffix);
-                }
-            }
-
-            var extension = Path.GetExtension(fileName);
-
-            return Path.Combine(Path.GetDirectoryName(fileName) ?? string.Empty, fileNameWithoutExtension + suffix + extension);
         }
 
         private static bool ShouldCopy32BitDnaOutput(BuildItemSpec item, IEnumerable<BuildItemSpec> buildItems)

--- a/Source/ExcelDna.AddIn.Tasks/ExcelDna.AddIn.Tasks.csproj
+++ b/Source/ExcelDna.AddIn.Tasks/ExcelDna.AddIn.Tasks.csproj
@@ -40,6 +40,8 @@
     <Compile Include="AbstractTask.cs" />
     <Compile Include="BuildItemSpec.cs" />
     <None Include="Properties\ExcelDna.AddIn.Tasks.targets" />
+    <Compile Include="CleanExcelAddIn.cs" />
+    <Compile Include="Common.cs" />
     <Compile Include="CreateExcelAddIn.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\ExcelDnaPhysicalFileSystem.cs" />
@@ -48,9 +50,11 @@
   <ItemGroup>
     <None Include="..\..\Package\ExcelDna.AddIn\content\ExcelDna.Build.props">
       <Link>ExcelDna.Build.props</Link>
+      <SubType>Designer</SubType>
     </None>
     <None Include="..\..\Package\ExcelDna.AddIn\tools\ExcelDna.AddIn.targets">
       <Link>ExcelDna.AddIn.targets</Link>
+      <SubType>Designer</SubType>
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Source/ExcelDna.AddIn.Tasks/Utils/ExcelDnaPhysicalFileSystem.cs
+++ b/Source/ExcelDna.AddIn.Tasks/Utils/ExcelDnaPhysicalFileSystem.cs
@@ -34,6 +34,11 @@ namespace ExcelDna.AddIn.Tasks.Utils
             File.Copy(sourceFileName, destFileName, overwrite);
         }
 
+        public void DeleteFile(string sourceFileName)
+        {
+            File.Delete(sourceFileName);
+        }
+
         public string GetRelativePath(string path, string workingDirectory = null)
         {
             workingDirectory = workingDirectory ?? Environment.CurrentDirectory;

--- a/Source/ExcelDna.AddIn.Tasks/Utils/IExcelDnaFileSystem.cs
+++ b/Source/ExcelDna.AddIn.Tasks/Utils/IExcelDnaFileSystem.cs
@@ -8,6 +8,7 @@
         void CreateDirectory(string path);
 
         void CopyFile(string sourceFileName, string destinationFileName, bool overwrite);
+        void DeleteFile(string sourceFileName);
 
         string GetRelativePath(string path, string workingDirectory = null);
     }

--- a/Source/ExcelDna/ExcelDna.vs2013.vcxproj
+++ b/Source/ExcelDna/ExcelDna.vs2013.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -28,27 +28,27 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfAtl>false</UseOfAtl>
     <CharacterSet>Unicode</CharacterSet>
     <CLRSupport>false</CLRSupport>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfAtl>false</UseOfAtl>
     <CharacterSet>Unicode</CharacterSet>
     <CLRSupport>false</CLRSupport>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget.sln
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SingleDnaFileDefaultSuffix", "SingleDnaFileDefaultSuffix\SingleDnaFileDefaultSuffix.csproj", "{69CFC6E4-EAF6-416A-B462-B586DC3E051D}"
 EndProject
@@ -16,6 +16,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SingleDnaFileInSubFolderDefaultSuffix", "SingleDnaFileInSubFolderDefaultSuffix\SingleDnaFileInSubFolderDefaultSuffix.csproj", "{3A3C232A-83DF-4FB1-9049-CF6A7E1C8351}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SingleDnaFileNoConfigDefaultSuffix", "SingleDnaFileNoConfigDefaultSuffix\SingleDnaFileNoConfigDefaultSuffix.csproj", "{34B3D54A-3D96-4754-BBED-B9DE164BAA80}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PreAndPostBuildEvents", "PreAndPostBuildEvents\PreAndPostBuildEvents.csproj", "{01805002-4F09-432A-B1E2-803C273671CB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MultipleAddInProjectTwo", "MultipleAddInProjectTwo\MultipleAddInProjectTwo.csproj", "{C174238C-B87F-41D3-BCAA-325AB66F0A7F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PreAndPostBuildEvents", "PreAndPostBuildEvents\PreAndPostBuildEvents.csproj", "{01805002-4F09-432A-B1E2-803C273671CB}"
 EndProject
@@ -57,6 +61,15 @@ Global
 		{01805002-4F09-432A-B1E2-803C273671CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{01805002-4F09-432A-B1E2-803C273671CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{01805002-4F09-432A-B1E2-803C273671CB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C174238C-B87F-41D3-BCAA-325AB66F0A7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C174238C-B87F-41D3-BCAA-325AB66F0A7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C174238C-B87F-41D3-BCAA-325AB66F0A7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C174238C-B87F-41D3-BCAA-325AB66F0A7F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4CE13234-A53E-4539-9AFF-D03F7DF2721C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4CE13234-A53E-4539-9AFF-D03F7DF2721C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4CE13234-A53E-4539-9AFF-D03F7DF2721C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4CE13234-A53E-4539-9AFF-D03F7DF2721C}.Release|Any CPU.Build.0 = Release|Any CPU
+		
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInBuild/AddIn-One-x.dna
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInBuild/AddIn-One-x.dna
@@ -1,0 +1,20 @@
+<DnaLibrary Name="MultipleAddInProjectOne 64-bit Add-In" RuntimeVersion="v4.0">
+  <ExternalLibrary Path="MultipleAddInProjectOne.dll" LoadFromBytes="true" Pack="true" />
+  
+  <!-- 
+       The RuntimeVersion attribute above allows two settings:
+       * RuntimeVersion="v2.0" - for .NET 2.0, 3.0 and 3.5
+       * RuntimeVersion="v4.0" - for .NET 4 and 4.5
+
+       Additional referenced assemblies can be specified by adding 'Reference' tags. 
+       These libraries will not be examined and registered with Excel as add-in libraries, 
+       but will be packed into the -packed.xll file and loaded at runtime as needed.
+       For example:
+       
+       <Reference Path="Another.Library.dll" Pack="true" />
+  
+       Excel-DNA also allows the xml for ribbon UI extensions to be specified in the .dna file.
+       See the main Excel-DNA site at http://excel-dna.net for downloads of the full distribution.
+  -->
+
+</DnaLibrary>

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInBuild/AddIn-One-x64-packed.xll.config
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInBuild/AddIn-One-x64-packed.xll.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="filename" value="AddIn-One-x64.config" />
+  </appSettings>
+</configuration>

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInBuild/AddIn-One-x64.dna
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInBuild/AddIn-One-x64.dna
@@ -1,0 +1,20 @@
+<DnaLibrary Name="MultipleAddInProjectOne 64-bit Add-In" RuntimeVersion="v4.0">
+  <ExternalLibrary Path="MultipleAddInProjectOne.dll" LoadFromBytes="true" Pack="true" />
+  
+  <!-- 
+       The RuntimeVersion attribute above allows two settings:
+       * RuntimeVersion="v2.0" - for .NET 2.0, 3.0 and 3.5
+       * RuntimeVersion="v4.0" - for .NET 4 and 4.5
+
+       Additional referenced assemblies can be specified by adding 'Reference' tags. 
+       These libraries will not be examined and registered with Excel as add-in libraries, 
+       but will be packed into the -packed.xll file and loaded at runtime as needed.
+       For example:
+       
+       <Reference Path="Another.Library.dll" Pack="true" />
+  
+       Excel-DNA also allows the xml for ribbon UI extensions to be specified in the .dna file.
+       See the main Excel-DNA site at http://excel-dna.net for downloads of the full distribution.
+  -->
+
+</DnaLibrary>

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInBuild/AddIn-One-x64.xll.config
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInBuild/AddIn-One-x64.xll.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="filename" value="AddIn-One-x64.config" />
+  </appSettings>
+</configuration>

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInProjectOne/AddIn-One-x64.config
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInProjectOne/AddIn-One-x64.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="filename" value="AddIn-One-x64.config" />
+  </appSettings>
+</configuration>

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInProjectOne/AddIn-One-x64.dna
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInProjectOne/AddIn-One-x64.dna
@@ -1,0 +1,20 @@
+<DnaLibrary Name="MultipleAddInProjectOne 64-bit Add-In" RuntimeVersion="v4.0">
+  <ExternalLibrary Path="MultipleAddInProjectOne.dll" LoadFromBytes="true" Pack="true" />
+  
+  <!-- 
+       The RuntimeVersion attribute above allows two settings:
+       * RuntimeVersion="v2.0" - for .NET 2.0, 3.0 and 3.5
+       * RuntimeVersion="v4.0" - for .NET 4 and 4.5
+
+       Additional referenced assemblies can be specified by adding 'Reference' tags. 
+       These libraries will not be examined and registered with Excel as add-in libraries, 
+       but will be packed into the -packed.xll file and loaded at runtime as needed.
+       For example:
+       
+       <Reference Path="Another.Library.dll" Pack="true" />
+  
+       Excel-DNA also allows the xml for ribbon UI extensions to be specified in the .dna file.
+       See the main Excel-DNA site at http://excel-dna.net for downloads of the full distribution.
+  -->
+
+</DnaLibrary>

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInProjectOne/AddIn.cs
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInProjectOne/AddIn.cs
@@ -1,0 +1,21 @@
+﻿using System.IO;
+using System.Windows.Forms;
+using ExcelDna.Integration;
+
+namespace MultipleAddInProjectChild
+{
+    public class AddIn : IExcelAddIn
+    {
+        public void AutoOpen()
+        {
+            var thisAddInName = Path.GetFileName((string)XlCall.Excel(XlCall.xlGetName));
+            var message = string.Format("Excel-DNA Add-In '{0}' loaded!", thisAddInName);
+
+            MessageBox.Show(message, thisAddInName, MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+
+        public void AutoClose()
+        {
+        }
+    }
+}

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInProjectOne/MultipleAddInProjectOne.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInProjectOne/MultipleAddInProjectOne.csproj
@@ -4,11 +4,11 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{C884DE99-F53F-4391-811C-31D9A9244D78}</ProjectGuid>
+    <ProjectGuid>{4CE13234-A53E-4539-9AFF-D03F7DF2721C}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>SingleDnaFileCustomSuffix_x64</RootNamespace>
-    <AssemblyName>SingleDnaFileCustomSuffix_x64</AssemblyName>
+    <RootNamespace>MultipleAddInProjectOne</RootNamespace>
+    <AssemblyName>MultipleAddInProjectOne</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\MultipleAddInBuild\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -37,16 +37,19 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AddIn.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
-    <None Include="MyLibrary-AddIn-x64.dna">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="AddIn-One-x64.config" />
+    <None Include="AddIn-One-x64.dna" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(ProjectDir)..\..\.exceldna.addin\tools\ExcelDna.AddIn.targets" />

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInProjectOne/Properties/AssemblyInfo.cs
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInProjectOne/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MultipleAddInProjectChild")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MultipleAddInProjectChild")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("4ce13234-a53e-4539-9aff-d03f7df2721c")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInProjectTwo/AddIn-Two-x64.config
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInProjectTwo/AddIn-Two-x64.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="filename" value="AddIn-Two-x64.config" />
+  </appSettings>
+</configuration>

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInProjectTwo/AddIn-Two-x64.dna
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInProjectTwo/AddIn-Two-x64.dna
@@ -1,0 +1,20 @@
+<DnaLibrary Name="MultipleAddInProjectTwo 64-bit Add-In" RuntimeVersion="v4.0">
+  <ExternalLibrary Path="MultipleAddInProjectTwo.dll" LoadFromBytes="true" Pack="true" />
+  
+  <!-- 
+       The RuntimeVersion attribute above allows two settings:
+       * RuntimeVersion="v2.0" - for .NET 2.0, 3.0 and 3.5
+       * RuntimeVersion="v4.0" - for .NET 4 and 4.5
+
+       Additional referenced assemblies can be specified by adding 'Reference' tags. 
+       These libraries will not be examined and registered with Excel as add-in libraries, 
+       but will be packed into the -packed.xll file and loaded at runtime as needed.
+       For example:
+       
+       <Reference Path="Another.Library.dll" Pack="true" />
+  
+       Excel-DNA also allows the xml for ribbon UI extensions to be specified in the .dna file.
+       See the main Excel-DNA site at http://excel-dna.net for downloads of the full distribution.
+  -->
+
+</DnaLibrary>

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInProjectTwo/AddIn.cs
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInProjectTwo/AddIn.cs
@@ -1,0 +1,20 @@
+﻿using System.IO;
+using System.Windows.Forms;
+using ExcelDna.Integration;
+namespace MultipleAddInProjectParent
+{
+    public class AddIn : IExcelAddIn
+    {
+        public void AutoOpen()
+        {
+            var thisAddInName = Path.GetFileName((string)XlCall.Excel(XlCall.xlGetName));
+            var message = string.Format("Excel-DNA Add-In '{0}' loaded!", thisAddInName);
+
+            MessageBox.Show(message, thisAddInName, MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+
+        public void AutoClose()
+        {
+        }
+    }
+}

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInProjectTwo/MultipleAddInProjectTwo.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInProjectTwo/MultipleAddInProjectTwo.csproj
@@ -4,11 +4,11 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{C884DE99-F53F-4391-811C-31D9A9244D78}</ProjectGuid>
+    <ProjectGuid>{C174238C-B87F-41D3-BCAA-325AB66F0A7F}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>SingleDnaFileCustomSuffix_x64</RootNamespace>
-    <AssemblyName>SingleDnaFileCustomSuffix_x64</AssemblyName>
+    <RootNamespace>MultipleAddInProjectTwo</RootNamespace>
+    <AssemblyName>MultipleAddInProjectTwo</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\MultipleAddInBuild\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -37,14 +37,21 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AddIn.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
-    <None Include="MyLibrary-AddIn-x64.dna">
+    <None Include="AddIn-Two-x64.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="AddIn-Two-x64.dna">
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInProjectTwo/Properties/AssemblyInfo.cs
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/MultipleAddInProjectTwo/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MultipleAddInProjectParent")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MultipleAddInProjectParent")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("c174238c-b87f-41d3-bcaa-325ab66f0a7f")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SeparateDnaFilesCustomSuffix_x86_x64/SeparateDnaFilesCustomSuffix_x86_x64.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SeparateDnaFilesCustomSuffix_x86_x64/SeparateDnaFilesCustomSuffix_x86_x64.csproj
@@ -54,6 +54,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(ProjectDir)..\..\.exceldna.addin\tools\ExcelDna.AddIn.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>ECHO Running ExcelDna **Pre-build** event</PreBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PostBuildEvent>ECHO Running ExcelDna **Post-build** event</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SeparateDnaFilesDefaultSuffix/SeparateDnaFilesDefaultSuffix.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SeparateDnaFilesDefaultSuffix/SeparateDnaFilesDefaultSuffix.csproj
@@ -54,6 +54,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(ProjectDir)..\..\.exceldna.addin\tools\ExcelDna.AddIn.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>ECHO Running ExcelDna **Pre-build** event</PreBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PostBuildEvent>ECHO Running ExcelDna **Post-build** event</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileCustomSuffix_x86/SingleDnaFileCustomSuffix_x86.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileCustomSuffix_x86/SingleDnaFileCustomSuffix_x86.csproj
@@ -50,6 +50,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(ProjectDir)..\..\.exceldna.addin\tools\ExcelDna.AddIn.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>ECHO Running ExcelDna **Pre-build** event</PreBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PostBuildEvent>ECHO Running ExcelDna **Post-build** event</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileDefaultSuffix/SingleDnaFileDefaultSuffix.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileDefaultSuffix/SingleDnaFileDefaultSuffix.csproj
@@ -50,6 +50,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(ProjectDir)..\..\.exceldna.addin\tools\ExcelDna.AddIn.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>ECHO Running ExcelDna **Pre-build** event</PreBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PostBuildEvent>ECHO Running ExcelDna **Post-build** event</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileInSubFolderDefaultSuffix/SingleDnaFileInSubFolderDefaultSuffix.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileInSubFolderDefaultSuffix/SingleDnaFileInSubFolderDefaultSuffix.csproj
@@ -50,6 +50,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(ProjectDir)..\..\.exceldna.addin\tools\ExcelDna.AddIn.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>ECHO Running ExcelDna **Pre-build** event</PreBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PostBuildEvent>ECHO Running ExcelDna **Post-build** event</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileNoConfigDefaultSuffix/SingleDnaFileNoConfigDefaultSuffix.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileNoConfigDefaultSuffix/SingleDnaFileNoConfigDefaultSuffix.csproj
@@ -49,6 +49,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(ProjectDir)..\..\.exceldna.addin\tools\ExcelDna.AddIn.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>ECHO Running ExcelDna **Pre-build** event</PreBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PostBuildEvent>ECHO Running ExcelDna **Post-build** event</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests/ExcelDna.AddIn.Tasks.IntegrationTests.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests/ExcelDna.AddIn.Tasks.IntegrationTests.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IntegrationTestBase.cs" />
+    <Compile Include="MultipleAddInIntegrationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SeparateDnaFilesCustomSuffix_x86_x64IntegrationTests.cs" />
     <Compile Include="SeparateDnaFilesDefaultSuffixIntegrationTests.cs" />

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests/IntegrationTestBase.cs
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests/IntegrationTestBase.cs
@@ -126,6 +126,32 @@ namespace ExcelDna.AddIn.Tasks.IntegrationTests
             }
         }
 
+        protected static void AssertFound(string basePath, string searchPattern, params string[] expectedFiles)
+        {
+            var existingFiles = Directory.GetFiles(basePath, searchPattern, SearchOption.AllDirectories)
+               .ToArray();
+
+            var expectedFilesWithBasePath = expectedFiles
+                .Select(f => Path.Combine(basePath, f))
+                .ToArray();
+
+            var filesMissing = expectedFilesWithBasePath.Except(existingFiles, StringComparer.OrdinalIgnoreCase).ToArray();
+            if (filesMissing.Length > 0)
+            {
+                Assert.Fail("Expected file(s) missing in the output: {0}", string.Join(", ", filesMissing));
+            }
+        }
+
+        protected void AssertNotFound(string fileName)
+        {
+            if (File.Exists(fileName))
+            {
+                Assert.Fail("File {0} exists", fileName);
+            }
+
+            Assert.Pass("File {0} does not exist", fileName);
+        }
+
         protected void AssertIdentical(string fileName1, string fileName2)
         {
             if (!File.Exists(fileName1))
@@ -141,6 +167,8 @@ namespace ExcelDna.AddIn.Tasks.IntegrationTests
             Assert.IsTrue(FilesHaveEqualHash(fileName1, fileName2), "Contents of {0} and {1} do not match",
                 fileName1, fileName2);
         }
+
+
 
         protected void Assert32BitXll(string xllFileName)
         {

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests/MultipleAddInIntegrationTests.cs
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests/MultipleAddInIntegrationTests.cs
@@ -1,0 +1,40 @@
+﻿using NUnit.Framework;
+
+namespace ExcelDna.AddIn.Tasks.IntegrationTests
+{
+    [TestFixture]
+    public class MultipleAddInIntegrationTests : IntegrationTestBase
+    {
+        [Test]
+        public void Multiple_AddIn_Projects_Built_To_The_Same_Directory_Should_Only_Clean_Themselves()
+        {
+            const string projectOneBasePath = @"MultipleAddInProjectOne\";
+            const string projectTwoBasePath = @"MultipleAddInProjectTwo\";
+
+            const string projectOutDir = projectOneBasePath + @"..\MultipleAddInBuild\";
+
+            MsBuild(projectOneBasePath + "MultipleAddInProjectOne.csproj /t:Build /p:Configuration=Release /v:m " + MsBuildParam("OutputPath", @"..\MultipleAddInBuild\"));
+            MsBuild(projectTwoBasePath + "MultipleAddInProjectTwo.csproj /t:Build /p:Configuration=Release /v:m " + MsBuildParam("OutputPath", @"..\MultipleAddInBuild\"));
+            MsBuild(projectTwoBasePath + "MultipleAddInProjectTwo.csproj /t:Clean /p:Configuration=Release /v:m " + MsBuildParam("OutputPath", @"..\MultipleAddInBuild\"));
+
+            //The .DNA files, XLL + config files should remain for project one
+            AssertFound(projectOutDir, "*.dna", "AddIn-One-x.dna", "AddIn-One-x64.dna");
+            AssertFound(projectOutDir, "*.xll", "AddIn-One-x.xll", "AddIn-One-x-packed.xll", "AddIn-One-x64.xll", "AddIn-One-x64-packed.xll");
+            AssertFound(projectOutDir, "*.xll.config", new string[0]);
+
+            AssertIdentical(projectOneBasePath + "AddIn-One-x64.dna", projectOutDir + "AddIn-One-x64.dna");
+            AssertIdentical(projectOneBasePath + "AddIn-One-x64.config", projectOutDir + "AddIn-One-x64.xll.config");
+
+            //Assert project two files have been removed
+            AssertNotFound(projectOutDir + "AddIn-Two-x-packed.xll");
+            AssertNotFound(projectOutDir + "AddIn-Two-x64-packed.xll.config");
+            AssertNotFound(projectOutDir + "AddIn-Two-x64-packed.xll");
+            AssertNotFound(projectOutDir + "AddIn-Two-x64.xll.config");
+            AssertNotFound(projectOutDir + "AddIn-Two-x64.xll");
+            AssertNotFound(projectOutDir + "AddIn-Two-x64.dna");
+            AssertNotFound(projectOutDir + "AddIn-Two-x.xll");
+            AssertNotFound(projectOutDir + "AddIn-Two-x.dna");
+        }
+    }
+}
+


### PR DESCRIPTION
Changes for the build clean task to remove the delete * which was causing problems when building multiple add-ins to the same directory.

Also fixed some integration tests that didn't seem to be working.
I did this by adding the following to the csproj files.

  <PropertyGroup>
    <PreBuildEvent>ECHO Running ExcelDna **Pre-build** event</PreBuildEvent>
  </PropertyGroup>
  <PropertyGroup>
    <PostBuildEvent>ECHO Running ExcelDna **Post-build** event</PostBuildEvent>
  </PropertyGroup>

I've kept the methods / names as close as possible to the existing.
So there is probably some room for tidy up around that (particularly in relation to packed add-in deletion). Very happy for feedback etc etc

Also the issue of cleaning add-in files that get renamed (currently they will not be cleaned as there is no tracking of them. The delete * did not have this problem as everything was cleaned up)