### PR TITLE
Add support for group ExcelFunctionAttribute and ExcelCommandAttribute

### DIFF
--- a/Distribution/Samples/ExplicitExports.dna
+++ b/Distribution/Samples/ExplicitExports.dna
@@ -23,6 +23,28 @@
 		End Function	
 	End Module
 
+	<ExcelFunction(Category:="ExplicitModule")> _
+	Public Module VisibleModule
+		Function MultiplyThem(x, y)
+			MultiplyThem = x * y
+		End Function
+
+    <ExcelFunction(Name:="SubtractThem")> _
+		Function SubThem(x, y)
+			SubThem = x - y
+		End Function
+	End Module
+
+	Public Module InvisibleModule
+		Function MultiplyThem(x, y)
+			MultiplyThem = x * y
+		End Function
+
+		Function SubThem(x, y)
+			SubThem = x - y
+		End Function
+	End Module
+
 ]]>
 </Project>
 </DnaLibrary>

--- a/Distribution/Samples/GroupAttributes.dna
+++ b/Distribution/Samples/GroupAttributes.dna
@@ -1,0 +1,45 @@
+<DnaLibrary Name="Attributes Sample" Language="C#">
+<![CDATA[
+
+  using ExcelDna.Integration;
+
+  [ExcelFunction(Category="VolatileFuncs", IsVolatile=true)]
+  public class MyClass {
+
+    public static double funcA(double x, double y) {
+      return (x + y) ;
+    }
+
+    [ExcelFunction(IsVolatile=false)]
+    public static double funcB(double x, double y) {
+      return (x * y) ;
+    }
+
+    [ExcelFunction(Name="Cfunc")]
+    public static double funcC(double x, double y) {
+      return (x - y) ;
+    }
+
+    [ExcelFunction(Category="NotVolatileFuncs", IsVolatile=false)]
+    public static double funcD(double x, double y) {
+      return (x / y) ;
+    }
+
+  }
+
+  [ExcelCommand(MenuName="SampleMenu")]
+  public class MyMenuClass {
+
+    [ExcelCommand(MenuText="MenuItem 1")]
+    public static void aaa() {}
+
+    [ExcelCommand(MenuText="MenuItem 2")]
+    public static void bbb() {}
+
+    [ExcelCommand(MenuName="SampleMenu 2", MenuText="Item 1")]
+    public static void ccc() {}
+
+  }
+
+]]>
+</DnaLibrary>

--- a/Distribution/Samples/GroupAttributesVB.dna
+++ b/Distribution/Samples/GroupAttributesVB.dna
@@ -1,0 +1,46 @@
+<DnaLibrary Name="AttributesVB Sample" Language="VB">
+<![CDATA[
+
+  <ExcelFunction(Category:="VolatileFuncs", IsVolatile:=true)> _
+  Public Module MyModule
+
+    Function funcA(x As Object, y As Object) As Object
+      return x + y
+    End Function
+
+    <ExcelFunction(IsVolatile:=false)> _
+    Function funcB(x As Object, y As Object) As Object
+      return x * y
+    End Function
+
+    <ExcelFunction(Name:="Cfunc")> _
+    Function funcC(x As Object, y As Object) As Object
+      return x - y
+    End Function
+
+    <ExcelFunction(Category:="NotVolatileFuncs", IsVolatile:=false)> _
+    Function funcD(x As Object, y As Object) As Object
+      return x / y
+    End Function
+
+  End Module
+
+  <ExcelCommand(MenuName:="SampleMenu")> _
+  Public Module MyMenuModule
+
+    <ExcelCommand(MenuText:="MenuItem 1")> _
+    Sub aaa()
+    End Sub
+
+    <ExcelCommand(MenuText:="MenuItem 2")> _
+    Sub bbb()
+    End Sub
+
+    <ExcelCommand(MenuName:="SampleMenu 2", MenuText:="Item 1")> _
+    Sub ccc()
+    End Sub
+
+  End Module
+
+]]>
+</DnaLibrary>

--- a/Source/ExcelDna.Integration/AssemblyLoader.cs
+++ b/Source/ExcelDna.Integration/AssemblyLoader.cs
@@ -167,6 +167,16 @@ namespace ExcelDna.Integration
 					return true;
 				}
 			}
+      atts = mi.DeclaringType.GetCustomAttributes(false);
+			foreach (object att in atts)
+			{
+				Type attType = att.GetType();
+                if (TypeHasAncestorWithFullName(attType, "ExcelDna.Integration.ExcelFunctionAttribute") ||
+                    TypeHasAncestorWithFullName(attType, "ExcelDna.Integration.ExcelCommandAttribute" ) )
+				{
+					return true;
+				}
+			}
 			return false;
 		}
 

--- a/Source/ExcelDna.Integration/ExcelAttributes.cs
+++ b/Source/ExcelDna.Integration/ExcelAttributes.cs
@@ -5,21 +5,61 @@ using System;
 
 namespace ExcelDna.Integration
 {
-	[AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
 	public class ExcelFunctionAttribute : Attribute
 	{
 		public string Name = null;
 		public string Description = null;
 		public string Category = null;
 		public string HelpTopic = null;
-		public bool   IsVolatile = false;
-        public bool   IsHidden = false;
-		public bool   IsExceptionSafe = false;
-		public bool   IsMacroType = false;
-        public bool   IsThreadSafe = false;
-        public bool   IsClusterSafe = false;
-        public bool   ExplicitRegistration = false;
-        public bool   SuppressOverwriteError = false;
+
+		private bool? isVolatile;
+		public bool IsVolatile {
+			get { return isVolatile ?? false; }
+			set { isVolatile = value; }
+		}
+
+		private bool? isHidden;
+		public bool IsHidden {
+			get { return isHidden ?? false; }
+			set { isHidden = value; }
+		}
+
+		private bool? isExceptionSafe;
+		public bool IsExceptionSafe {
+			get { return isExceptionSafe ?? false; }
+			set { isExceptionSafe = value; }
+		}
+
+		private bool? isMacroType;
+		public bool IsMacroType {
+			get { return isMacroType ?? false; }
+			set { isMacroType = value; }
+		}
+
+		private bool? isThreadSafe;
+		public bool IsThreadSafe {
+			get { return isThreadSafe ?? false; }
+			set { isThreadSafe = value; }
+		}
+
+		private bool? isClusterSafe;
+		public bool IsClusterSafe {
+			get { return isClusterSafe ?? false; }
+			set { isClusterSafe = value; }
+		}
+
+		private bool? explicitRegistration;
+		public bool ExplicitRegistration {
+			get { return explicitRegistration ?? false; }
+			set { explicitRegistration = value; }
+		}
+
+		private bool? suppressOverwriteError;
+		public bool SuppressOverwriteError {
+			get { return suppressOverwriteError ?? false; }
+			set { suppressOverwriteError = value; }
+		}
 
 		public ExcelFunctionAttribute()
 		{
@@ -28,6 +68,21 @@ namespace ExcelDna.Integration
 		public ExcelFunctionAttribute(string description)
 		{
 			Description = description;
+		}
+
+		public void MergeGroupAttributes(ExcelFunctionAttribute ca) {
+			if (Description == null) Description = ca.Description;
+			if (Category == null) Category = ca.Category;
+			if (HelpTopic == null) HelpTopic = ca.HelpTopic;
+
+			if (!isVolatile.HasValue) isVolatile = ca.isVolatile;
+			if (!isHidden.HasValue) isHidden = ca.isHidden;
+			if (!isExceptionSafe.HasValue) isExceptionSafe = ca.isExceptionSafe;
+			if (!isMacroType.HasValue) isMacroType = ca.isMacroType;
+			if (!isThreadSafe.HasValue) isThreadSafe = ca.isThreadSafe;
+			if (!isClusterSafe.HasValue) isClusterSafe = ca.isClusterSafe;
+			if (!explicitRegistration.HasValue) explicitRegistration = ca.explicitRegistration;
+			if (!suppressOverwriteError.HasValue) suppressOverwriteError = ca.suppressOverwriteError;
 		}
 	}
 
@@ -48,7 +103,7 @@ namespace ExcelDna.Integration
 		}
 	}
 
-	[AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
+	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
 	public class ExcelCommandAttribute : Attribute
 	{
 		public string Name = null;
@@ -57,9 +112,24 @@ namespace ExcelDna.Integration
 		public string ShortCut = null;
 		public string MenuName = null;
 		public string MenuText = null;
-        public bool   IsExceptionSafe = false;
-        public bool   ExplicitRegistration = false;
-        public bool   SuppressOverwriteError = false;
+
+		private bool? isExceptionSafe;
+		public bool IsExceptionSafe {
+			get { return isExceptionSafe ?? false; }
+			set { isExceptionSafe = value; }
+		}
+
+		private bool? explicitRegistration;
+		public bool ExplicitRegistration {
+			get { return explicitRegistration ?? false; }
+			set { explicitRegistration = value; }
+		}
+
+		private bool? suppressOverwriteError;
+		public bool SuppressOverwriteError {
+			get { return suppressOverwriteError ?? false; }
+			set { suppressOverwriteError = value; }
+		}
 
         [Obsolete("ExcelFunctions can be declared hidden, not ExcelCommands.")]
 		public bool IsHidden = false;
@@ -71,6 +141,16 @@ namespace ExcelDna.Integration
 		public ExcelCommandAttribute(string description)
 		{
 			Description = description;
+		}
+
+		public void MergeGroupAttributes(ExcelCommandAttribute ca) {
+			if (Description == null) Description = ca.Description;
+			if (HelpTopic == null) HelpTopic = ca.HelpTopic;
+			if (MenuName == null) MenuName = ca.MenuName;
+
+			if (!isExceptionSafe.HasValue) isExceptionSafe = ca.isExceptionSafe;
+			if (!explicitRegistration.HasValue) explicitRegistration = ca.explicitRegistration;
+			if (!suppressOverwriteError.HasValue) suppressOverwriteError = ca.suppressOverwriteError;
 		}
 	}
 }


### PR DESCRIPTION
ExcelFunctionAttribute and ExcelCommandAttribute can be now declared at
class / Module level and they are applied to the contained methods (cfr. #119).
Attributes declared at method level take precedence over the ones specified
at class level for what they declare (cfr. Distribution/Samples/GroupAttributes.dna
for examples).