### PR TITLE
Update ExcelDnaPhysicalFileSystem.CopyFile to copy files without copying source file attributes

### DIFF
--- a/Source/ExcelDna.AddIn.Tasks/Utils/ExcelDnaPhysicalFileSystem.cs
+++ b/Source/ExcelDna.AddIn.Tasks/Utils/ExcelDnaPhysicalFileSystem.cs
@@ -22,16 +22,22 @@ namespace ExcelDna.AddIn.Tasks.Utils
 
         public void CopyFile(string sourceFileName, string destFileName, bool overwrite)
         {
-            if (overwrite)
-            {
-                var fileInfo = new FileInfo(destFileName);
-                if (fileInfo.Exists && fileInfo.IsReadOnly)
-                {
-                    fileInfo.IsReadOnly = false;
-                }
-            }
+            var outputFileMode = overwrite ? FileMode.Create : FileMode.CreateNew;
 
-            File.Copy(sourceFileName, destFileName, overwrite);
+            using (var inputStream = new FileStream(sourceFileName, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var outputStream = new FileStream(destFileName, outputFileMode, FileAccess.Write, FileShare.None))
+            {
+                const int bufferSize = 16384; // 16 Kb
+                var buffer = new byte[bufferSize];
+
+                int bytesRead;
+
+                do
+                {
+                    bytesRead = inputStream.Read(buffer, 0, bufferSize);
+                    outputStream.Write(buffer, 0, bytesRead);
+                } while (bytesRead == bufferSize);
+            }
         }
 
         public void DeleteFile(string sourceFileName)


### PR DESCRIPTION
Pull-request #136 effectively resolves issue #135 by making sure even read-only files can be deleted.

This pull-request improves on that resolution by making sure file attributes are not copied across to the output folder, therefore not creating read-only files in the first place, in case the attributes of the source file have been changed (as per @Rand-Random's reported issue with source control marking files as read-only)