### PR TITLE
Improve debugging experience / Automatically set debugger options

### DIFF
--- a/Package/ExcelDna.AddIn/content/ExcelDna.Build.props
+++ b/Package/ExcelDna.AddIn/content/ExcelDna.Build.props
@@ -14,6 +14,28 @@
   -->
 
   <!--
+    Configuration properties for debugging Excel-DNA add-ins
+  -->
+  <PropertyGroup>
+    <!--
+      Enable/Disable setting the debug options when building the project
+    -->
+    <RunExcelDnaSetDebuggerOptions Condition="'$(RunExcelDnaSetDebuggerOptions)' == ''">true</RunExcelDnaSetDebuggerOptions>
+
+    <!--
+      Override the path of EXCEL.EXE used for debugging the project, if you need
+      By default, it will use the latest version of Excel it can find on the machine
+    -->
+    <ExcelDnaExcelExePath Condition="'$(ExcelDnaExcelExePath)' == ''"></ExcelDnaExcelExePath>
+
+    <!--
+      Override the name of the .XLL add-in to use when debugging the project, if you need
+      By default, it will use the first unpacked .xll add-in that matches the bitness of EXCEL.EXE
+    -->
+    <ExcelDnaAddInForDebugging Condition="'$(ExcelDnaAddInForDebugging)' == ''"></ExcelDnaAddInForDebugging>
+  </PropertyGroup>
+
+  <!--
     Configuration properties for building .dna files
   -->
   <PropertyGroup>

--- a/Package/ExcelDna.AddIn/tools/ExcelDna.AddIn.targets
+++ b/Package/ExcelDna.AddIn/tools/ExcelDna.AddIn.targets
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask TaskName="ExcelDna.AddIn.Tasks.CreateExcelAddIn" AssemblyFile="ExcelDna.AddIn.Tasks.dll" />
+  <UsingTask TaskName="ExcelDna.AddIn.Tasks.SetDebuggerOptions" AssemblyFile="ExcelDna.AddIn.Tasks.dll" />
   <UsingTask TaskName="ExcelDna.AddIn.Tasks.CleanExcelAddIn" AssemblyFile="ExcelDna.AddIn.Tasks.dll" />
+  <UsingTask TaskName="ExcelDna.AddIn.Tasks.CreateExcelAddIn" AssemblyFile="ExcelDna.AddIn.Tasks.dll" />
 
   <PropertyGroup>
     <ExcelDnaTargetsImported>true</ExcelDnaTargetsImported>
@@ -18,10 +19,11 @@
   </PropertyGroup>
 
   <!--
-    Extend the Build target to call our ExcelDnaBuild and ExcelDnaPack targets
+    Extend the Build target to call our ExcelDnaDebugger, ExcelDnaBuild, and ExcelDnaPack targets
   -->
   <PropertyGroup>
     <BuildDependsOn>
+      ExcelDnaSetDebuggerOptions;
       $(BuildDependsOn);
       ExcelDnaBuild;
       ExcelDnaPack;
@@ -41,6 +43,7 @@
     Default values for configuration properties - in case they were not set in via .props file or command-line
   -->
   <PropertyGroup>
+    <RunExcelDnaSetDebuggerOptions Condition="'$(RunExcelDnaSetDebuggerOptions)' == ''">true</RunExcelDnaSetDebuggerOptions>
     <RunExcelDnaClean Condition="'$(RunExcelDnaClean)' == ''">true</RunExcelDnaClean>
     <RunExcelDnaBuild Condition="'$(RunExcelDnaBuild)' == ''">true</RunExcelDnaBuild>
     <RunExcelDnaPack Condition="'$(RunExcelDnaPack)' == ''">true</RunExcelDnaPack>
@@ -58,6 +61,31 @@
     <ExcelDnaPackCompressResources Condition="'$(ExcelDnaPackCompressResources)' == ''">true</ExcelDnaPackCompressResources>
     <ExcelDnaPackRunMultithreaded Condition="'$(ExcelDnaPackRunMultithreaded)' == ''">true</ExcelDnaPackRunMultithreaded>
   </PropertyGroup>
+
+  <!--
+    Configure debugger options (Path for EXCEL.EXE, add-in to open, etc).
+  -->
+  <Target Name="ExcelDnaSetDebuggerOptions" BeforeTargets="PreBuildEvent" Condition="$(RunExcelDnaSetDebuggerOptions) AND '$(BuildingInsideVisualStudio)' == 'true'">
+    <Message Text="---" Importance="High" />
+
+    <Error Text="ExcelDna32BitAddInSuffix and ExcelDna64BitAddInSuffix cannot be identical. Fix your ExcelDna.Build.props file"
+           Condition="'$(ExcelDna32BitAddInSuffix)' == '$(ExcelDna64BitAddInSuffix)'" />
+
+    <ItemGroup>
+      <ExcelDnaFilesInProject Include="@(None)" />
+      <ExcelDnaFilesInProject Include="@(Content)" />
+    </ItemGroup>
+
+    <SetDebuggerOptions
+      ProjectName="$(MSBuildProjectName)"
+      ExcelExePath="$(ExcelDnaExcelExePath)"
+      AddInForDebugging="$(ExcelDnaAddInForDebugging)"
+      FilesInProject="@(ExcelDnaFilesInProject)"
+      OutDirectory="$(OutDir)"
+      FileSuffix32Bit="$(ExcelDna32BitAddInSuffix)"
+      FileSuffix64Bit="$(ExcelDna64BitAddInSuffix)">
+    </SetDebuggerOptions>
+  </Target>
 
   <!--
     Target that removes .dna, .xll, and .xll.config from the build output folder
@@ -83,7 +111,6 @@
       PackIsEnabled="$(RunExcelDnaPack)"
       PackedFileSuffix="$(ExcelDnaPackXllSuffix)">
     </CleanExcelAddIn>
-
   </Target>
 
   <!--

--- a/Package/ExcelDna.AddIn/tools/uninstall.ps1
+++ b/Package/ExcelDna.AddIn/tools/uninstall.ps1
@@ -2,7 +2,6 @@ param($installPath, $toolsPath, $package, $project)
     Write-Host "Starting ExcelDna.AddIn uninstall script"
 
     $dteVersion = $project.DTE.Version
-    $isBeforeVS2015 = ($dteVersion -lt 14.0)
     $isFSharpProject = ($project.Type -eq "F#")
     $projectName = $project.Name
 
@@ -27,36 +26,6 @@ param($installPath, $toolsPath, $package, $project)
             $dnaFileItem.Name = "_UNINSTALLED_${suffix}_${dnaFileName}"
         }
     }
-
-
-    if ($isFSharpProject -and $isBeforeVS2015)
-    {
-        # No Debug information was set.
-    }
-    else
-    {
-        # Clean Debug settings
-        $exeValue = Get-ItemProperty -Path Registry::HKEY_CLASSES_ROOT\Excel.XLL\shell\Open\command -name "(default)"
-        if ($exeValue -match "`".*`"")
-        {
-            $exePath = $matches[0] -replace "`"", ""
-
-            # Find Debug configuration and set debugger settings.
-            $debugProject = $project.ConfigurationManager | Where-Object {$_.ConfigurationName -eq "Debug"}
-            if ($null -ne $debugProject)
-            {
-                if (($debugProject.Properties.Item("StartAction").Value -eq 1) -and 
-                    ($debugProject.Properties.Item("StartArguments").Value -match "\.xll"))
-                {
-                    Write-Host "`tClearing Debug start settings"
-                    $debugProject.Properties.Item("StartAction").Value = 0
-                    $debugProject.Properties.Item("StartProgram").Value = ""
-                    $debugProject.Properties.Item("StartArguments").Value  = ""
-                }
-            }
-        }
-    }
-
 
     Write-Host "`Removing build targets from the project"
     

--- a/Source/ExcelDna.AddIn.Tasks/AbstractTask.cs
+++ b/Source/ExcelDna.AddIn.Tasks/AbstractTask.cs
@@ -1,24 +1,40 @@
-﻿using Microsoft.Build.Framework;
+﻿using System;
+using Microsoft.Build.Framework;
 
 namespace ExcelDna.AddIn.Tasks
 {
     public abstract class AbstractTask : ITask
     {
+        private readonly string _targetName;
+
+        protected AbstractTask(string targetName)
+        {
+            if (string.IsNullOrWhiteSpace(targetName))
+            {
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(targetName));
+            }
+
+            _targetName = targetName;
+        }
+
         public abstract bool Execute();
 
         protected void LogMessage(string message, MessageImportance importance = MessageImportance.High)
         {
-            BuildEngine.LogMessageEvent(new BuildMessageEventArgs("ExcelDnaBuild: " + message, "ExcelDnaBuild", "ExcelDnaBuild", importance));
+            BuildEngine.LogMessageEvent(new BuildMessageEventArgs(string.Format("{0}: {1}", _targetName, message),
+                _targetName, _targetName, importance));
         }
 
         protected void LogWarning(string code, string message)
         {
-            BuildEngine.LogWarningEvent(new BuildWarningEventArgs("ExcelDnaBuild", code, null, 0, 0, 0, 0, message, "ExcelDnaBuild", "ExcelDnaBuild"));
+            BuildEngine.LogWarningEvent(new BuildWarningEventArgs(_targetName, code, null, 0, 0, 0, 0, message,
+                _targetName, _targetName));
         }
 
         protected void LogError(string code, string message)
         {
-            BuildEngine.LogErrorEvent(new BuildErrorEventArgs("ExcelDnaBuild", code, null, 0, 0, 0, 0, message, "ExcelDnaBuild", "ExcelDnaBuild"));
+            BuildEngine.LogErrorEvent(new BuildErrorEventArgs(_targetName, code, null, 0, 0, 0, 0, message, _targetName,
+                _targetName));
         }
 
         public IBuildEngine BuildEngine { get; set; }

--- a/Source/ExcelDna.AddIn.Tasks/AbstractTask.cs
+++ b/Source/ExcelDna.AddIn.Tasks/AbstractTask.cs
@@ -19,6 +19,15 @@ namespace ExcelDna.AddIn.Tasks
 
         public abstract bool Execute();
 
+        protected void LogDebugMessage(string message)
+        {
+            #if DEBUG
+                LogMessage(message, MessageImportance.High);
+            #else
+                LogMessage(message, MessageImportance.Low);
+            #endif
+        }
+
         protected void LogMessage(string message, MessageImportance importance = MessageImportance.High)
         {
             BuildEngine.LogMessageEvent(new BuildMessageEventArgs(string.Format("{0}: {1}", _targetName, message),

--- a/Source/ExcelDna.AddIn.Tasks/CleanExcelAddIn.cs
+++ b/Source/ExcelDna.AddIn.Tasks/CleanExcelAddIn.cs
@@ -21,6 +21,7 @@ namespace ExcelDna.AddIn.Tasks
         }
 
         public CleanExcelAddIn(IExcelDnaFileSystem fileSystem)
+            : base("ExcelDnaClean")
         {
             if (fileSystem == null)
             {

--- a/Source/ExcelDna.AddIn.Tasks/CleanExcelAddIn.cs
+++ b/Source/ExcelDna.AddIn.Tasks/CleanExcelAddIn.cs
@@ -35,17 +35,17 @@ namespace ExcelDna.AddIn.Tasks
         {
             try
             {
+                LogDebugMessage("Running CleanExcelAddIn MSBuild Task");
+
                 LogDiagnostics();
 
                 FilesInProject = FilesInProject ?? new ITaskItem[0];
-                LogMessage("Number of files in project: " + FilesInProject.Length, MessageImportance.Low);
+                LogDebugMessage("Number of files in project: " + FilesInProject.Length);
 
                 _common = new BuildTaskCommon(FilesInProject, OutDirectory, FileSuffix32Bit, FileSuffix64Bit);
 
                 var existingBuiltFiles = _common.GetBuildItemsForDnaFiles();
                 _packedFilesToDelete = GetPackedFilesToDelete(existingBuiltFiles);
-
-                LogMessage("---");
 
                 // Get the packed name versions : Refactor this + build items
                 DeleteAddInFiles(existingBuiltFiles);
@@ -63,14 +63,14 @@ namespace ExcelDna.AddIn.Tasks
 
         private void LogDiagnostics()
         {
-            LogMessage("----Arguments----", MessageImportance.Low);
-            LogMessage("FilesInProject: " + (FilesInProject ?? new ITaskItem[0]).Length, MessageImportance.Low);
-            LogMessage("OutDirectory: " + OutDirectory, MessageImportance.Low);
-            LogMessage("Xll32FilePath: " + Xll32FilePath, MessageImportance.Low);
-            LogMessage("Xll64FilePath: " + Xll64FilePath, MessageImportance.Low);
-            LogMessage("FileSuffix32Bit: " + FileSuffix32Bit, MessageImportance.Low);
-            LogMessage("FileSuffix64Bit: " + FileSuffix64Bit, MessageImportance.Low);
-            LogMessage("-----------------", MessageImportance.Low);
+            LogDebugMessage("----Arguments----");
+            LogDebugMessage("FilesInProject: " + (FilesInProject ?? new ITaskItem[0]).Length);
+            LogDebugMessage("OutDirectory: " + OutDirectory);
+            LogDebugMessage("Xll32FilePath: " + Xll32FilePath);
+            LogDebugMessage("Xll64FilePath: " + Xll64FilePath);
+            LogDebugMessage("FileSuffix32Bit: " + FileSuffix32Bit);
+            LogDebugMessage("FileSuffix64Bit: " + FileSuffix64Bit);
+            LogDebugMessage("-----------------");
         }
 
         private List<ITaskItem> GetPackedFilesToDelete(BuildItemSpec[] existingBuiltFiles)
@@ -142,6 +142,7 @@ namespace ExcelDna.AddIn.Tasks
         {
             if (_fileSystem.FileExists(path))
             {
+                LogDebugMessage("Deleting file " + path);
                 _fileSystem.DeleteFile(path);
             }
         }

--- a/Source/ExcelDna.AddIn.Tasks/CreateExcelAddIn.cs
+++ b/Source/ExcelDna.AddIn.Tasks/CreateExcelAddIn.cs
@@ -22,6 +22,7 @@ namespace ExcelDna.AddIn.Tasks
         }
 
         public CreateExcelAddIn(IExcelDnaFileSystem fileSystem)
+            : base("ExcelDnaBuild")
         {
             if (fileSystem == null)
             {

--- a/Source/ExcelDna.AddIn.Tasks/CreateExcelAddIn.cs
+++ b/Source/ExcelDna.AddIn.Tasks/CreateExcelAddIn.cs
@@ -36,6 +36,8 @@ namespace ExcelDna.AddIn.Tasks
         {
             try
             {
+                LogDebugMessage("Running CreateExcelAddIn MSBuild Task");
+
                 LogDiagnostics();
 
                 RunSanityChecks();
@@ -44,7 +46,7 @@ namespace ExcelDna.AddIn.Tasks
                 DnaFilesToPack = new ITaskItem[0];
 
                 FilesInProject = FilesInProject ?? new ITaskItem[0];
-                LogMessage("Number of files in project: " + FilesInProject.Length, MessageImportance.Low);
+                LogDebugMessage("Number of files in project: " + FilesInProject.Length);
 
                 _configFilesInProject = GetConfigFilesInProject();
                 _common = new BuildTaskCommon(FilesInProject, OutDirectory, FileSuffix32Bit, FileSuffix64Bit);
@@ -53,7 +55,7 @@ namespace ExcelDna.AddIn.Tasks
 
                 TryBuildAddInFor32Bit(buildItemsForDnaFiles);
 
-                LogMessage("---");
+                LogMessage("---", MessageImportance.High);
 
                 TryBuildAddInFor64Bit(buildItemsForDnaFiles);
 
@@ -71,16 +73,16 @@ namespace ExcelDna.AddIn.Tasks
 
         private void LogDiagnostics()
         {
-            LogMessage("----Arguments----", MessageImportance.Low);
-            LogMessage("FilesInProject: " + (FilesInProject ?? new ITaskItem[0]).Length, MessageImportance.Low);
-            LogMessage("OutDirectory: " + OutDirectory, MessageImportance.Low);
-            LogMessage("Xll32FilePath: " + Xll32FilePath, MessageImportance.Low);
-            LogMessage("Xll64FilePath: " + Xll64FilePath, MessageImportance.Low);
-            LogMessage("Create32BitAddIn: " + Create32BitAddIn, MessageImportance.Low);
-            LogMessage("Create64BitAddIn: " + Create64BitAddIn, MessageImportance.Low);
-            LogMessage("FileSuffix32Bit: " + FileSuffix32Bit, MessageImportance.Low);
-            LogMessage("FileSuffix64Bit: " + FileSuffix64Bit, MessageImportance.Low);
-            LogMessage("-----------------", MessageImportance.Low);
+            LogDebugMessage("----Arguments----");
+            LogDebugMessage("FilesInProject: " + (FilesInProject ?? new ITaskItem[0]).Length);
+            LogDebugMessage("OutDirectory: " + OutDirectory);
+            LogDebugMessage("Xll32FilePath: " + Xll32FilePath);
+            LogDebugMessage("Xll64FilePath: " + Xll64FilePath);
+            LogDebugMessage("Create32BitAddIn: " + Create32BitAddIn);
+            LogDebugMessage("Create64BitAddIn: " + Create64BitAddIn);
+            LogDebugMessage("FileSuffix32Bit: " + FileSuffix32Bit);
+            LogDebugMessage("FileSuffix64Bit: " + FileSuffix64Bit);
+            LogDebugMessage("-----------------");
         }
 
         private void RunSanityChecks()

--- a/Source/ExcelDna.AddIn.Tasks/ExcelDna.AddIn.Tasks.csproj
+++ b/Source/ExcelDna.AddIn.Tasks/ExcelDna.AddIn.Tasks.csproj
@@ -44,6 +44,7 @@
     <Compile Include="BuildTaskCommon.cs" />
     <Compile Include="CreateExcelAddIn.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utils\Bitness.cs" />
     <Compile Include="Utils\ExcelDnaPhysicalFileSystem.cs" />
     <Compile Include="Utils\IExcelDnaFileSystem.cs" />
   </ItemGroup>

--- a/Source/ExcelDna.AddIn.Tasks/ExcelDna.AddIn.Tasks.csproj
+++ b/Source/ExcelDna.AddIn.Tasks/ExcelDna.AddIn.Tasks.csproj
@@ -43,6 +43,8 @@
   <ItemGroup>
     <Compile Include="AbstractTask.cs" />
     <Compile Include="BuildItemSpec.cs" />
+    <Compile Include="Utils\ExcelDnaProject.cs" />
+    <Compile Include="Utils\IExcelDnaProject.cs" />
     <None Include="Properties\ExcelDna.AddIn.Tasks.targets" />
     <Compile Include="CleanExcelAddIn.cs" />
     <Compile Include="BuildTaskCommon.cs" />

--- a/Source/ExcelDna.AddIn.Tasks/ExcelDna.AddIn.Tasks.csproj
+++ b/Source/ExcelDna.AddIn.Tasks/ExcelDna.AddIn.Tasks.csproj
@@ -45,7 +45,9 @@
     <Compile Include="CreateExcelAddIn.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\Bitness.cs" />
+    <Compile Include="Utils\ExcelDetector.cs" />
     <Compile Include="Utils\ExcelDnaPhysicalFileSystem.cs" />
+    <Compile Include="Utils\IExcelDetector.cs" />
     <Compile Include="Utils\IExcelDnaFileSystem.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/ExcelDna.AddIn.Tasks/ExcelDna.AddIn.Tasks.csproj
+++ b/Source/ExcelDna.AddIn.Tasks/ExcelDna.AddIn.Tasks.csproj
@@ -43,6 +43,7 @@
   <ItemGroup>
     <Compile Include="AbstractTask.cs" />
     <Compile Include="BuildItemSpec.cs" />
+    <Compile Include="SetDebuggerOptions.cs" />
     <Compile Include="Utils\ExcelDnaProject.cs" />
     <Compile Include="Utils\IExcelDnaProject.cs" />
     <None Include="Properties\ExcelDna.AddIn.Tasks.targets" />

--- a/Source/ExcelDna.AddIn.Tasks/ExcelDna.AddIn.Tasks.csproj
+++ b/Source/ExcelDna.AddIn.Tasks/ExcelDna.AddIn.Tasks.csproj
@@ -30,11 +30,15 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Management" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AbstractTask.cs" />
@@ -45,6 +49,7 @@
     <Compile Include="CreateExcelAddIn.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\Bitness.cs" />
+    <Compile Include="Utils\DevToolsEnvironment.cs" />
     <Compile Include="Utils\ExcelDetector.cs" />
     <Compile Include="Utils\ExcelDnaPhysicalFileSystem.cs" />
     <Compile Include="Utils\IExcelDetector.cs" />

--- a/Source/ExcelDna.AddIn.Tasks/SetDebuggerOptions.cs
+++ b/Source/ExcelDna.AddIn.Tasks/SetDebuggerOptions.cs
@@ -1,0 +1,206 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Build.Framework;
+using ExcelDna.AddIn.Tasks.Utils;
+
+namespace ExcelDna.AddIn.Tasks
+{
+    public class SetDebuggerOptions : AbstractTask
+    {
+        private readonly IExcelDetector _excelDetector;
+        private readonly IExcelDnaProject _dte;
+        private BuildTaskCommon _common;
+
+        public SetDebuggerOptions()
+            : this(new ExcelDetector(), new ExcelDnaProject())
+        {
+        }
+
+        public SetDebuggerOptions(IExcelDetector excelDetector, IExcelDnaProject dte)
+            : base("ExcelDnaSetDebuggerOptions")
+        {
+            if (excelDetector == null)
+            {
+                throw new ArgumentNullException("excelDetector");
+            }
+
+            if (dte == null)
+            {
+                throw new ArgumentNullException("dte");
+            }
+
+            _excelDetector = excelDetector;
+            _dte = dte;
+        }
+
+        public override bool Execute()
+        {
+            try
+            {
+                LogDebugMessage("Running SetDebuggerOptions MSBuild Task");
+
+                LogDiagnostics();
+
+                FilesInProject = FilesInProject ?? new ITaskItem[0];
+                LogDebugMessage("Number of files in project: " + FilesInProject.Length);
+
+                var excelExePath = GetExcelPath();
+                var addInForDebugging = GetAddInForDebugging(excelExePath);
+
+                if (!_dte.TrySetDebuggerOptions(ProjectName, excelExePath, addInForDebugging))
+                {
+                    LogWarning("DNA" + "DTE".GetHashCode(), "Unable to set the debugger options within Visual Studio.");
+                }
+            }
+            catch (Exception ex)
+            {
+                LogWarning("DNA" + ex.GetType().Name.GetHashCode(), ex.Message);
+            }
+
+            // Setting the debugger options is not essential to the build process, thus if anything
+            // goes wrong, we'll report errors and warnings, but will let the build continue
+            return true;
+        }
+
+        private string GetExcelPath()
+        {
+            var excelExePath = ExcelExePath;
+
+            try
+            {
+                if (string.IsNullOrWhiteSpace(excelExePath))
+                {
+                    if (!_excelDetector.TryFindLatestExcel(out excelExePath))
+                    {
+                        LogWarning("DNA" + "EXCEL.EXE".GetHashCode(), "Unable to find path where EXCEL.EXE is located");
+                        return excelExePath;
+                    }
+                }
+
+                if (!File.Exists(excelExePath))
+                {
+                    LogWarning("DNA" + "EXCEL.EXE".GetHashCode(),
+                        "EXCEL.EXE not found on disk at location " + excelExePath);
+                }
+            }
+            finally
+            {
+                LogMessage("EXCEL.EXE path for debugging: " + excelExePath);
+            }
+
+            return excelExePath;
+        }
+
+        private string GetAddInForDebugging(string excelExePath)
+        {
+            var addInForDebugging = AddInForDebugging;
+
+            try
+            {
+                if (string.IsNullOrWhiteSpace(addInForDebugging))
+                {
+                    if (!TryGetExcelAddInForDebugging(excelExePath, out addInForDebugging))
+                    {
+                        LogWarning("DNA" + "ADDIN".GetHashCode(), "Unable to find add-in to Debug");
+                    }
+                }
+            }
+            finally
+            {
+                LogMessage("Add-In for debugging: " + addInForDebugging);
+            }
+
+            return addInForDebugging;
+        }
+
+        private bool TryGetExcelAddInForDebugging(string excelExePath, out string addinForDebugging)
+        {
+            addinForDebugging = null;
+
+            Bitness excelBitness;
+            if (!_excelDetector.TryFindExcelBitness(excelExePath, out excelBitness))
+            {
+                return false;
+            }
+
+            _common = new BuildTaskCommon(FilesInProject, OutDirectory, FileSuffix32Bit, FileSuffix64Bit);
+
+            var outputBuildItems = _common.GetBuildItemsForDnaFiles();
+
+            var firstAddIn = outputBuildItems.FirstOrDefault();
+            if (firstAddIn == null) return false;
+
+            switch (excelBitness)
+            {
+                case Bitness.Bit32:
+                {
+                    addinForDebugging = firstAddIn.OutputXllFileNameAs32Bit;
+                    return true;
+                }
+                case Bitness.Bit64:
+                {
+                    addinForDebugging = firstAddIn.OutputXllFileNameAs64Bit;
+                    return true;
+                }
+                default:
+                {
+                    return false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The name of the project being compiled
+        /// </summary>
+        [Required]
+        public string ProjectName { get; set; }
+
+        /// <summary>
+        /// The path to EXCEL.EXE that should be used for debugging
+        /// This overrides the automatic detection of the latest Excel installed
+        /// </summary>
+        public string ExcelExePath { get; set; }
+
+        /// <summary>
+        /// The path to .XLL file name that should be used for debugging
+        /// This overrides the automatic detection depending on Excel's bitness
+        /// </summary>
+        public string AddInForDebugging { get; set; }        
+
+        /// <summary>
+        /// The list of files in the project marked as Content or None
+        /// </summary>
+        [Required]
+        public ITaskItem[] FilesInProject { get; set; }
+
+        /// <summary>
+        /// The directory in which the built files were written to
+        /// </summary>
+        [Required]
+        public string OutDirectory { get; set; }
+
+        /// <summary>
+        /// The name suffix for 32-bit .dna files
+        /// </summary>
+        public string FileSuffix32Bit { get; set; }
+
+        /// <summary>
+        /// The name suffix for 64-bit .dna files
+        /// </summary>
+        public string FileSuffix64Bit { get; set; }
+
+        private void LogDiagnostics()
+        {
+            LogDebugMessage("----Arguments----");
+            LogDebugMessage("ProjectName: " + ProjectName);
+            LogDebugMessage("ExcelExePath: " + ExcelExePath);
+            LogDebugMessage("AddInForDebugging: " + AddInForDebugging);
+            LogDebugMessage("FilesInProject: " + (FilesInProject ?? new ITaskItem[0]).Length);
+            LogDebugMessage("OutDirectory: " + OutDirectory);
+            LogDebugMessage("FileSuffix32Bit: " + FileSuffix32Bit);
+            LogDebugMessage("FileSuffix64Bit: " + FileSuffix64Bit);
+            LogDebugMessage("-----------------");
+        }
+    }
+}

--- a/Source/ExcelDna.AddIn.Tasks/Utils/Bitness.cs
+++ b/Source/ExcelDna.AddIn.Tasks/Utils/Bitness.cs
@@ -1,0 +1,9 @@
+﻿namespace ExcelDna.AddIn.Tasks.Utils
+{
+    public enum Bitness
+    {
+        Unknown = 0,
+        Bit32 = 32,
+        Bit64 = 64,
+    }
+}

--- a/Source/ExcelDna.AddIn.Tasks/Utils/DevToolsEnvironment.cs
+++ b/Source/ExcelDna.AddIn.Tasks/Utils/DevToolsEnvironment.cs
@@ -1,0 +1,220 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Management;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using System.Text.RegularExpressions;
+
+namespace ExcelDna.AddIn.Tasks.Utils
+{
+    internal class DevToolsEnvironment : IDisposable
+    {
+        private bool _isMessageFilterRegistered;
+
+        public EnvDTE.Project GetProjectByName(string projectName)
+        {
+            var vsProcessId = GetVisualStudioProcessId();
+
+            var dte = GetDevToolsEnvironment(vsProcessId);
+            if (dte == null) return null;
+
+            if (!_isMessageFilterRegistered)
+            {
+                MessageFilter.Register();
+                _isMessageFilterRegistered = true;
+            }
+
+            var project = dte
+                .Solution
+                .Projects
+                .OfType<EnvDTE.Project>()
+                .SingleOrDefault(p =>
+                    string.Compare(p.Name, projectName, StringComparison.OrdinalIgnoreCase) == 0);
+
+            return project;
+        }
+
+        public void Dispose()
+        {
+            if (_isMessageFilterRegistered)
+            {
+                MessageFilter.Revoke();
+            }
+        }
+
+        private int GetVisualStudioProcessId()
+        {
+            try
+            {
+                var process = Process.GetCurrentProcess();
+
+                if (process.ProcessName.ToLower().Contains("devenv"))
+                {
+                    // We're being compiled directly by Visual Studio
+                    return process.Id;
+                }
+
+                // We're being compiled by other tool (e.g. MSBuild) called from Visual Studio
+                // therefore, Visual Studio is our parent process
+
+                using (var searcher = new ManagementObjectSearcher("SELECT * FROM Win32_Process WHERE ProcessId = " + process.Id))
+                {
+                    foreach (var obj in searcher.Get())
+                    {
+                        var parentId = Convert.ToInt32((uint)obj["ParentProcessId"]);
+                        var parentProcessName = Process.GetProcessById(parentId).ProcessName;
+
+                        if (parentProcessName.ToLower().Contains("devenv"))
+                        {
+                            return parentId;
+                        }
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // Do nothing
+            }
+
+            return -1;
+        }
+
+        private EnvDTE.DTE GetDevToolsEnvironment(int processId)
+        {
+            object runningObject = null;
+
+            IBindCtx bindCtx = null;
+            IRunningObjectTable rot = null;
+            IEnumMoniker enumMonikers = null;
+
+            try
+            {
+                Marshal.ThrowExceptionForHR(CreateBindCtx(reserved: 0, ppbc: out bindCtx));
+                bindCtx.GetRunningObjectTable(out rot);
+                rot.EnumRunning(out enumMonikers);
+
+                var moniker = new IMoniker[1];
+                var numberFetched = IntPtr.Zero;
+
+                while (enumMonikers.Next(1, moniker, numberFetched) == 0)
+                {
+                    var runningObjectMoniker = moniker[0];
+
+                    string name = null;
+
+                    try
+                    {
+                        if (runningObjectMoniker != null)
+                        {
+                            runningObjectMoniker.GetDisplayName(bindCtx, null, out name);
+                        }
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                        // Do nothing, there is something in the ROT that we do not have access to
+                    }
+
+                    var monikerRegex = new Regex(@"!VisualStudio.DTE\.\d+\.\d+\:" + processId, RegexOptions.IgnoreCase);
+                    if (!string.IsNullOrEmpty(name) && monikerRegex.IsMatch(name))
+                    {
+                        Marshal.ThrowExceptionForHR(rot.GetObject(runningObjectMoniker, out runningObject));
+                        break;
+                    }
+                }
+            }
+            finally
+            {
+                if (enumMonikers != null)
+                {
+                    Marshal.ReleaseComObject(enumMonikers);
+                }
+
+                if (rot != null)
+                {
+                    Marshal.ReleaseComObject(rot);
+                }
+
+                if (bindCtx != null)
+                {
+                    Marshal.ReleaseComObject(bindCtx);
+                }
+            }
+
+            return runningObject as EnvDTE.DTE;
+        }
+
+        [DllImport("ole32.dll")]
+        private static extern int CreateBindCtx(uint reserved, out IBindCtx ppbc);
+
+        // Implement the IOleMessageFilter interface
+        [DllImport("Ole32.dll")]
+        private static extern int CoRegisterMessageFilter(IOleMessageFilter newFilter, out IOleMessageFilter oldFilter);
+
+        /// <summary>
+        /// Contains the IOleMessageFilter thread error-handling functions
+        /// See https://msdn.microsoft.com/en-us/library/ms228772
+        /// </summary>
+        private class MessageFilter : IOleMessageFilter
+        {
+            public static void Register()
+            {
+                // Register the IOleMessageFilter to handle any threading errors
+                // See https://msdn.microsoft.com/en-us/library/ms228772
+
+                IOleMessageFilter newFilter = new MessageFilter();
+
+                IOleMessageFilter _;
+                CoRegisterMessageFilter(newFilter, out _);
+            }
+
+            public static void Revoke()
+            {
+                IOleMessageFilter _;
+
+                // Turn off the IOleMessageFilter
+                CoRegisterMessageFilter(null, out _);
+            }
+
+            // IOleMessageFilter functions
+            // Handle incoming thread requests
+            int IOleMessageFilter.HandleInComingCall(int dwCallType, IntPtr hTaskCaller, int dwTickCount, IntPtr lpInterfaceInfo)
+            {
+                // Return the flag SERVERCALL_ISHANDLED
+                return 0;
+            }
+
+            // Thread call was rejected, so try again
+            int IOleMessageFilter.RetryRejectedCall(IntPtr hTaskCallee, int dwTickCount, int dwRejectType)
+            {
+                if (dwRejectType == 2) // SERVERCALL_RETRYLATER
+                {
+                    // Retry the thread call immediately if return >= 0 & < 100.
+                    return 99;
+                }
+
+                // Too busy; cancel call
+                return -1;
+            }
+
+            int IOleMessageFilter.MessagePending(IntPtr hTaskCallee, int dwTickCount, int dwPendingType)
+            {
+                // Return the flag PENDINGMSG_WAITDEFPROCESS
+                return 2;
+            }
+        }
+
+        [ComImport, Guid("00000016-0000-0000-C000-000000000046"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IOleMessageFilter
+        {
+            [PreserveSig]
+            int HandleInComingCall(int dwCallType, IntPtr hTaskCaller, int dwTickCount, IntPtr lpInterfaceInfo);
+
+            [PreserveSig]
+            int RetryRejectedCall(IntPtr hTaskCallee, int dwTickCount, int dwRejectType);
+
+            [PreserveSig]
+            int MessagePending(IntPtr hTaskCallee, int dwTickCount, int dwPendingType);
+        }
+    }
+}

--- a/Source/ExcelDna.AddIn.Tasks/Utils/ExcelDetector.cs
+++ b/Source/ExcelDna.AddIn.Tasks/Utils/ExcelDetector.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Security.AccessControl;
+using Microsoft.Win32;
+
+namespace ExcelDna.AddIn.Tasks.Utils
+{
+    internal class ExcelDetector : IExcelDetector
+    {
+        public bool TryFindLatestExcel(out string excelExePath)
+        {
+            excelExePath = null;
+
+            var versions = (ExcelVersions[])Enum.GetValues(typeof(ExcelVersions));
+            var versionsNumbersDescending = versions.Select(v => (int)v).OrderByDescending(vn => vn);
+
+            foreach (var versionNumber in versionsNumbersDescending)
+            {
+                var keyPath = string.Format(@"Software\Microsoft\Office\{0}.0\Excel\InstallRoot", versionNumber);
+
+                if (!TryGetExcelExePathFromRegistry(keyPath, out excelExePath)) continue;
+
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool TryFindExcelBitness(string excelExePath, out Bitness bitness)
+        {
+            bitness = Bitness.Unknown;
+
+            if (!File.Exists(excelExePath))
+            {
+                throw new Exception("Excel path specified in Registry not found on disk: " + excelExePath);
+            }
+
+            using (var fileStream = File.OpenRead(excelExePath))
+            {
+                using (var reader = new BinaryReader(fileStream))
+                {
+                    // See http://www.microsoft.com/whdc/system/platform/firmware/PECOFF.mspx
+                    // Offset to PE header is always at 0x3C.
+                    // The PE header starts with "PE\0\0" =  0x50 0x45 0x00 0x00,
+                    // followed by a 2-byte machine type field (see the document above for the enum).
+
+                    fileStream.Seek(0x3c, SeekOrigin.Begin);
+                    var peOffset = reader.ReadInt32();
+
+                    fileStream.Seek(peOffset, SeekOrigin.Begin);
+                    var peHead = reader.ReadUInt32();
+
+                    if (peHead != 0x00004550) // "PE\0\0", little-endian
+                    {
+                        throw new Exception("Unable to find PE header in file");
+                    }
+
+                    var machineType = (MachineType)reader.ReadUInt16();
+
+                    switch (machineType)
+                    {
+                        case MachineType.ImageFileMachineI386:
+                            {
+                                bitness = Bitness.Bit32;
+                                return true;
+                            }
+                        case MachineType.ImageFileMachineAmd64:
+                        case MachineType.ImageFileMachineIa64:
+                            {
+                                bitness = Bitness.Bit64;
+                                return true;
+                            }
+                        default:
+                            {
+                                bitness = Bitness.Unknown;
+                                return false;
+                            }
+                    }
+                }
+            }
+        }
+
+        private bool TryGetExcelExePathFromRegistry(string keyPath, out string excelExePath)
+        {
+            return TryGetExcelExePathFromRegistry(keyPath, RegistryView.Registry64, out excelExePath) ||
+                   TryGetExcelExePathFromRegistry(keyPath, RegistryView.Registry32, out excelExePath);
+        }
+
+        private bool TryGetExcelExePathFromRegistry(string keyPath, RegistryView registryView, out string excelExePath)
+        {
+            excelExePath = null;
+
+            using (var baseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, registryView))
+            {
+                using (var excelKey = baseKey.OpenSubKey(keyPath, RegistryKeyPermissionCheck.ReadSubTree,
+                    RegistryRights.ReadKey))
+                {
+                    if (excelKey == null) return false;
+
+                    var installRoot = excelKey.GetValue("Path");
+                    if (installRoot != null)
+                    {
+                        excelExePath = Path.Combine(installRoot.ToString(), "EXCEL.EXE");
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private enum ExcelVersions
+        {
+            // ReSharper disable UnusedMember.Local
+            Excel2003 = 11, // Office 2003 - 11.0
+            Excel2007 = 12, // Office 2007 - 12.0
+            Excel2010 = 14, // Office 2010 - 14.0 (sic!)
+            Excel2013 = 15, // Office 2013 - 15.0
+            Excel2016 = 16, // Office 2016 - 16.0
+            // ReSharper restore UnusedMember.Local
+        }
+
+        private enum MachineType : ushort
+        {
+            ImageFileMachineAmd64 = 0x8664,
+            ImageFileMachineI386 = 0x14c,
+            ImageFileMachineIa64 = 0x200,
+        }
+    }
+}

--- a/Source/ExcelDna.AddIn.Tasks/Utils/ExcelDnaProject.cs
+++ b/Source/ExcelDna.AddIn.Tasks/Utils/ExcelDnaProject.cs
@@ -1,0 +1,35 @@
+﻿using System.IO;
+
+namespace ExcelDna.AddIn.Tasks.Utils
+{
+    public class ExcelDnaProject : IExcelDnaProject
+    {
+        public bool TrySetDebuggerOptions(string projectName, string excelExePath, string excelAddInToDebug)
+        {
+            using (var dte = new DevToolsEnvironment())
+            {
+                var project = dte.GetProjectByName(projectName);
+                if (project != null)
+                {
+                    var configuration = project
+                        .ConfigurationManager
+                        .ActiveConfiguration;
+
+                    var startAction = configuration.Properties.Item("StartAction");
+                    var startProgram = configuration.Properties.Item("StartProgram");
+                    var startArguments = configuration.Properties.Item("StartArguments");
+
+                    startAction.Value = 1; // Start external program
+                    startProgram.Value = excelExePath;
+                    startArguments.Value = string.Format(@"""{0}""", Path.GetFileName(excelAddInToDebug));
+
+                    project.Save(string.Empty);
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/Source/ExcelDna.AddIn.Tasks/Utils/IExcelDetector.cs
+++ b/Source/ExcelDna.AddIn.Tasks/Utils/IExcelDetector.cs
@@ -1,0 +1,9 @@
+﻿namespace ExcelDna.AddIn.Tasks.Utils
+{
+    public interface IExcelDetector
+    {
+        bool TryFindLatestExcel(out string excelExePath);
+
+        bool TryFindExcelBitness(string excelExePath, out Bitness bitness);
+    }
+}

--- a/Source/ExcelDna.AddIn.Tasks/Utils/IExcelDnaProject.cs
+++ b/Source/ExcelDna.AddIn.Tasks/Utils/IExcelDnaProject.cs
@@ -1,0 +1,7 @@
+﻿namespace ExcelDna.AddIn.Tasks.Utils
+{
+    public interface IExcelDnaProject
+    {
+        bool TrySetDebuggerOptions(string projectName, string excelExePath, string excelAddInToDebug);
+    }
+}

--- a/Source/ExcelDna.sln.DotSettings
+++ b/Source/ExcelDna.sln.DotSettings
@@ -1,8 +1,12 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArgumentsStyleLiteral/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArgumentsStyleNamedExpression/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertPropertyToExpressionBody/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantArgumentDefaultValue/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantCommaInEnumDeclaration/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantCommaInInitializer/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantExplicitParamsArrayCreation/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseNameofExpression/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseNullPropagation/@EntryIndexedValue">DO_NOT_SHOW</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseStringInterpolation/@EntryIndexedValue">DO_NOT_SHOW</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseStringInterpolation/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=DTE/@EntryIndexedValue">DTE</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
This PR resolves issues #18 and #19.

The main goal of this PR is to improve the debugging experience of ExcelDna add-ins by automatically detecting the latest Excel version installed on the machine, as well as Excel's bitness (i.e. 32-bit or 64-bit), and set the debugger options in the project where ExcelDna.AddIn is installed, on every build, to the Excel detected, and the right add-in (32 or 64) to be opened with Excel.

This PR allows the following user experiences:
1. **Start debugging an add-in immediately after downloading code from source control**, regardless of the Excel version that the original developer was using, without having to define any setting in the project debug configuration;

2.  **Start debugging an add-in immediately after renaming the `.dna` file**, without having to change any setting in the project configuration (as it automatically updates the debug settings with the new `.xll` file name);

3. **Start debugging an add-in immediately after changing suffixes for add-ins in the `ExcelDna.Build.props` file**, without having to change any setting in the project configuration (as it automatically updates the debug settings with the new `.xll` file name);

4. **Dynamically target different Excel installations on the machine** via conditions in `ExcelDna.Build.props`.

---

## How to override the default behavior

The `ExcelDna.Build.props` that gets added into the `Properties` folder of the add-in, includes three (3) new variables:

* `RunExcelDnaSetDebuggerOptions` - Allows the user to turn off/on setting the debug options during build;

* `ExcelDnaExcelExePath` - Allows the user to override the default behavior of using the most recent version of Excel installed on the machine, and instead use a particular Excel installation, by providing the full path of the EXCEL.EXE that should be used;

* `ExcelDnaAddInForDebugging` - Allows the user to override the default behavior of using the add-in that matches the EXCEL.EXE bitness (i.e. 32-bit or 64-bit), and instead use a particular add-in, by providing the file name of the `.xll` file that should be passed to EXCEL.EXE as an argument. 

Of course, ideally users would use the variables above only for tests during debugging sessions, and change them back to their original values before committing the `ExcelDna.Build.props` file to source control, as changes to these variables would impact the user experiences described earlier above.

---

I tested this PR with C#, VB .NET, and F# projects on Visual Studio 2017 (Enterprise and Community) as well as Visual Studio 2015 (Enterprise), and would welcome any further testing.

---

/cc @govert,  @garethhayter, @konne 