### PR TITLE
Update .mailmap to map to Govert's recent commits

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -4,5 +4,5 @@ Govert van Drimmelen <govert@icon.co.za> TFSSERVICE <RNO\_TFSSERVICE>
 Govert van Drimmelen <govert@icon.co.za> MCLWEB <RNO\_MCLWEB>
 Govert van Drimmelen <govert@icon.co.za> [TFS09]\Project Collection Service Accounts <vstfs:///Framework/IdentityDomain/a83551a4-30f6-4d81-a974-c6ced450ddbf\Project Collection Service Accounts>
 Govert van Drimmelen <govert@icon.co.za> Project Collection Service Accounts <vstfs:///Framework/IdentityDomain/a83551a4-30f6-4d81-a974-c6ced450ddbf\Project Collection Service Accounts>
+Govert van Drimmelen <govert@icon.co.za> Govert <govert@icon.co.za>
 Caio Proiete <caio.proiete@gmail.com> Caio Proiete <cproiete@nephilacapital.com>
-


### PR DESCRIPTION
Tiny PR to map @govert's most recent commits. Noticed this when my build server didn't group commits [`c14eb9a`](https://github.com/Excel-DNA/ExcelDna/commit/c14eb9a40db2d0b7eb414c1edc2bc898cb217d69) and [`66e152e`](https://github.com/Excel-DNA/ExcelDna/commit/66e152e0e728dc2227ef9e89a045dbb965a80dcc) when building ExcelDna, as it thinks they were made by different people:

* [`c14eb9a`](https://github.com/Excel-DNA/ExcelDna/commit/c14eb9a40db2d0b7eb414c1edc2bc898cb217d69) - Govert van Drimmelen <govert@****.co.za>
* [`66e152e`](https://github.com/Excel-DNA/ExcelDna/commit/66e152e0e728dc2227ef9e89a045dbb965a80dcc) - Govert <govert@****.co.za>

@govert You might want to fix this moving forward on your machines:

    git config --global user.name "Govert van Drimmelen"

    # inside the git repository, just in case
    git config user.name "Govert van Drimmelen"