### PR TITLE
ExcelDnaPhysicalFileSystem.CopyFile: Remove ReadOnly flag if overwriting existing file

### DIFF
--- a/Source/ExcelDna.AddIn.Tasks/Utils/ExcelDnaPhysicalFileSystem.cs
+++ b/Source/ExcelDna.AddIn.Tasks/Utils/ExcelDnaPhysicalFileSystem.cs
@@ -22,6 +22,15 @@ namespace ExcelDna.AddIn.Tasks.Utils
 
         public void CopyFile(string sourceFileName, string destFileName, bool overwrite)
         {
+            if (overwrite)
+            {
+                var destFileInfo = new FileInfo(destFileName);
+                if (destFileInfo.Exists && destFileInfo.IsReadOnly)
+                {
+                    destFileInfo.IsReadOnly = false;
+                }
+            }
+
             var outputFileMode = overwrite ? FileMode.Create : FileMode.CreateNew;
 
             using (var inputStream = new FileStream(sourceFileName, FileMode.Open, FileAccess.Read, FileShare.Read))


### PR DESCRIPTION
Tiny improvement to `ExcelDnaPhysicalFileSystem` to make it for a smoother upgrade from v0.34.6 to vNext.

The new implementation that was merged with PR #139 makes sure that attributes from the source file are not copied to the output folder.

However, there's an edge-case for v0.34.6 users who were affected by the issue PR #139 resolves (i.e. use TFS/Subversion) and they might get an error the first time they try to build the ExcelDna project without doing a full `Rebuild` or `Clean` first, as the output folder will already contain read-only files that need to be overwritten.