### PR TITLE
Convert fields in our attributes to virtual properties, to allow dynamic behavior

### DIFF
--- a/Source/ExcelDna.Integration/ExcelAttributes.cs
+++ b/Source/ExcelDna.Integration/ExcelAttributes.cs
@@ -42,9 +42,17 @@ namespace ExcelDna.Integration
 	[AttributeUsage(AttributeTargets.Parameter, Inherited = false, AllowMultiple = false)]
 	public class ExcelArgumentAttribute : Attribute
 	{
-		public string Name = null;
-		public string Description = null;
-		public bool   AllowReference = false;
+		private string _description;
+
+		public virtual string Name { get; set; }
+
+		public virtual string Description
+		{
+			get { return _description; }
+			set { _description = value; }
+		}
+
+		public virtual bool AllowReference { get; set; }
 
 		public ExcelArgumentAttribute()
 		{
@@ -52,7 +60,7 @@ namespace ExcelDna.Integration
 
 		public ExcelArgumentAttribute(string description)
 		{
-			Description = description;
+			_description = description;
 		}
 	}
 

--- a/Source/ExcelDna.Integration/ExcelAttributes.cs
+++ b/Source/ExcelDna.Integration/ExcelAttributes.cs
@@ -67,17 +67,25 @@ namespace ExcelDna.Integration
 	[AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
 	public class ExcelCommandAttribute : Attribute
 	{
-		public string Name = null;
-		public string Description = null;
-		public string HelpTopic = null;
-		public string ShortCut = null;
-		public string MenuName = null;
-		public string MenuText = null;
-        public bool   IsExceptionSafe = false;
-        public bool   ExplicitRegistration = false;
-        public bool   SuppressOverwriteError = false;
+		private string _description;
 
-        [Obsolete("ExcelFunctions can be declared hidden, not ExcelCommands.")]
+		public virtual string Name { get; set; }
+
+		public virtual string Description
+		{
+			get { return _description; }
+			set { _description = value; }
+		}
+
+		public virtual string HelpTopic { get; set; }
+		public virtual string ShortCut { get; set; }
+		public virtual string MenuName { get; set; }
+		public virtual string MenuText { get; set; }
+		public virtual bool IsExceptionSafe { get; set; }
+		public virtual bool ExplicitRegistration { get; set; }
+		public virtual bool SuppressOverwriteError { get; set; }
+
+		[Obsolete("ExcelFunctions can be declared hidden, not ExcelCommands.")]
 		public bool IsHidden = false;
 
 		public ExcelCommandAttribute()
@@ -86,7 +94,7 @@ namespace ExcelDna.Integration
 
 		public ExcelCommandAttribute(string description)
 		{
-			Description = description;
+			_description = description;
 		}
 	}
 }

--- a/Source/ExcelDna.Integration/ExcelAttributes.cs
+++ b/Source/ExcelDna.Integration/ExcelAttributes.cs
@@ -8,18 +8,26 @@ namespace ExcelDna.Integration
 	[AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
 	public class ExcelFunctionAttribute : Attribute
 	{
-		public string Name = null;
-		public string Description = null;
-		public string Category = null;
-		public string HelpTopic = null;
-		public bool   IsVolatile = false;
-        public bool   IsHidden = false;
-		public bool   IsExceptionSafe = false;
-		public bool   IsMacroType = false;
-        public bool   IsThreadSafe = false;
-        public bool   IsClusterSafe = false;
-        public bool   ExplicitRegistration = false;
-        public bool   SuppressOverwriteError = false;
+		private string _description;
+
+		public virtual string Name { get; set; }
+
+		public virtual string Description
+		{
+			get { return _description; }
+			set { _description = value; }
+		}
+
+		public virtual string Category { get; set; }
+		public virtual string HelpTopic { get; set; }
+		public virtual bool IsVolatile { get; set; }
+		public virtual bool IsHidden { get; set; }
+		public virtual bool IsExceptionSafe { get; set; }
+		public virtual bool IsMacroType { get; set; }
+		public virtual bool IsThreadSafe { get; set; }
+		public virtual bool IsClusterSafe { get; set; }
+		public virtual bool ExplicitRegistration { get; set; }
+		public virtual bool SuppressOverwriteError { get; set; }
 
 		public ExcelFunctionAttribute()
 		{
@@ -27,7 +35,7 @@ namespace ExcelDna.Integration
 
 		public ExcelFunctionAttribute(string description)
 		{
-			Description = description;
+			_description = description;
 		}
 	}
 


### PR DESCRIPTION
This PR makes it easier to implement dynamic behavior in our attributes such as described in #158.

By allowing devs to create their own `ExcelXXXAttribute`-derived classes and overriding its properties, we can more easily allow for dynamic behavior in said properties, without requiring fallback to custom registration.

For example, (after this PR gets merged) to implement a dynamic `HelpTopic` as described in #158, developers can create their own `ExcelFunctionAttribute`-derived class and build the `HelpTopic` dynamically:

```csharp
[AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
public class ExcelFunctionV2Attribute : ExcelFunctionAttribute
{
    public override string HelpTopic
    {
        get
        {
            var environment = ConfigurationManager.AppSettings["Environment"];
            return $"http://{environment}/help/{Name}";
        }

        set { throw new NotImplementedException(); }
    }
}
```

And, of course, decorating the function methods with the derived class, for it to work:

```csharp
public static class MyFunctions
{
    [ExcelFunctionV2]
    public static string Hello()
    {
        return "Hi";
    }
}
```
