### PR TITLE
Update NuGet package to use `build` feature for adding `.targets` files to projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ Package/nupkg/
 
 # Enable "build/" folder in the NuGet Packages folder since NuGet packages use it for MSBuild targets
 !packages/*/build/
+!Package/*/build/
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/Distribution/ChangeLog.txt
+++ b/Distribution/ChangeLog.txt
@@ -2,6 +2,7 @@ Version 0.35 (???)
 ------------------
 * Improve build tasks - more reliable clean-up and debugger detection.
 * Improve RTD and async QueueAsMacro reliability
+* Improve install process of ExcelDna.AddIn NuGet package (now requires NuGet 2.5)
 
 Version 0.34 (18 June 2017)
 ---------------------------

--- a/Package/ExcelDna.AddIn/ExcelDna.AddIn.nuspec
+++ b/Package/ExcelDna.AddIn/ExcelDna.AddIn.nuspec
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-    <metadata>
+    <metadata minClientVersion="2.5">
         <id>ExcelDna.AddIn</id>
         <version>0.34.6</version>
         <title>Excel-DNA Add-In</title>
@@ -34,7 +34,7 @@
         <file src="content\ExcelDna.Build.props" target="content\Properties\ExcelDna.Build.props" />
         <file src="tools\install.ps1" target="tools\install.ps1" />
         <file src="tools\uninstall.ps1" target="tools\uninstall.ps1" />
-        <file src="tools\ExcelDna.AddIn.targets" target="tools\ExcelDna.AddIn.targets" />
+        <file src="build\ExcelDna.AddIn.targets" target="build\ExcelDna.AddIn.targets" />
         <file src="tools\ExcelDna.AddIn.Tasks.dll" target="tools\ExcelDna.AddIn.Tasks.dll" />
         <file src="readme.txt" target="readme.txt" />
     </files>

--- a/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
+++ b/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask TaskName="ExcelDna.AddIn.Tasks.SetDebuggerOptions" AssemblyFile="ExcelDna.AddIn.Tasks.dll" />
-  <UsingTask TaskName="ExcelDna.AddIn.Tasks.CleanExcelAddIn" AssemblyFile="ExcelDna.AddIn.Tasks.dll" />
-  <UsingTask TaskName="ExcelDna.AddIn.Tasks.CreateExcelAddIn" AssemblyFile="ExcelDna.AddIn.Tasks.dll" />
-
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ExcelDnaTargetsImported>true</ExcelDnaTargetsImported>
+    <ExcelDnaToolsPath Condition="$(ExcelDnaToolsPath) == '' Or $(ExcelDnaToolsPath) == '*Undefined*'">$(MSBuildThisFileDirectory)..\tools\</ExcelDnaToolsPath>
   </PropertyGroup>
+
+  <UsingTask TaskName="ExcelDna.AddIn.Tasks.SetDebuggerOptions" AssemblyFile="$(ExcelDnaToolsPath)ExcelDna.AddIn.Tasks.dll" />
+  <UsingTask TaskName="ExcelDna.AddIn.Tasks.CleanExcelAddIn" AssemblyFile="$(ExcelDnaToolsPath)ExcelDna.AddIn.Tasks.dll" />
+  <UsingTask TaskName="ExcelDna.AddIn.Tasks.CreateExcelAddIn" AssemblyFile="$(ExcelDnaToolsPath)ExcelDna.AddIn.Tasks.dll" />
 
   <!--
     Extend the Clean target to call our ExcelDnaClean target
@@ -53,8 +53,6 @@
 
     <ExcelDna32BitAddInSuffix Condition="'$(ExcelDna32BitAddInSuffix)' == ''"></ExcelDna32BitAddInSuffix>
     <ExcelDna64BitAddInSuffix Condition="'$(ExcelDna64BitAddInSuffix)' == ''">64</ExcelDna64BitAddInSuffix>
-
-    <ExcelDnaToolsPath Condition="'$(ExcelDnaToolsPath)' == ''">$(MSBuildThisFileDirectory)</ExcelDnaToolsPath>
 
     <ExcelDnaPackExePath Condition="'$(ExcelDnaPackExePath)' == ''">$(ExcelDnaToolsPath)ExcelDnaPack.exe</ExcelDnaPackExePath>
     <ExcelDnaPackXllSuffix Condition="'$(ExcelDnaPackXllSuffix)' == ''">-packed</ExcelDnaPackXllSuffix>

--- a/Package/ExcelDna.AddIn/tools/install.ps1
+++ b/Package/ExcelDna.AddIn/tools/install.ps1
@@ -48,43 +48,6 @@ param($installPath, $toolsPath, $package, $project)
         }
     }
 
-    Write-Host "`tAdding build targets to the project"
-
-    # This is the MSBuild targets file to add
-    $targetsFile = [System.IO.Path]::Combine($toolsPath, 'ExcelDna.AddIn.targets')
-
-    # Need to load MSBuild assembly if it's not loaded yet
-    Add-Type -AssemblyName 'Microsoft.Build, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
-
-    # Grab the loaded MSBuild project for the project
-    $msbuild = [Microsoft.Build.Evaluation.ProjectCollection]::GlobalProjectCollection.GetLoadedProjects($project.FullName) | Select-Object -First 1
-
-    # Make the path to the targets file relative
-    $projectUri = new-object Uri($project.FullName, [System.UriKind]::Absolute)
-    $targetUri = new-object Uri($targetsFile, [System.UriKind]::Absolute)
-    $relativePath = [System.Uri]::UnescapeDataString($projectUri.MakeRelativeUri($targetUri).ToString()).Replace([System.IO.Path]::AltDirectorySeparatorChar, [System.IO.Path]::DirectorySeparatorChar)
-
-    # Add the import with a condition, to allow the project to load without the targets present
-    $import = $msbuild.Xml.AddImport($relativePath)
-    $import.Condition = "Exists('$relativePath')"
-
-    # Add a target to fail the build when our targets are not imported
-    $target = $msbuild.Xml.AddTarget("EnsureExcelDnaTargetsImported")
-    $target.BeforeTargets = "BeforeBuild"
-    $target.Condition = "'`$(ExcelDnaTargetsImported)' == ''"
-
-    # If the targets don't exist at the time the target runs, package restore didn't run
-    $errorTask = $target.AddTask("Error")
-    $errorTask.Condition = "!Exists('$relativePath') And ('`$(RunExcelDnaBuild)' != '' And `$(RunExcelDnaBuild))"
-    $errorTask.SetParameter("Text", "You are trying to build with ExcelDna, but the NuGet targets file that ExcelDna depends on is not available on this computer. This is probably because the ExcelDna package has not been committed to source control, or NuGet Package Restore is not enabled. Please enable NuGet Package Restore to download them. For more information, see http://go.microsoft.com/fwlink/?LinkID=317567.");
-    $errorTask.SetParameter("HelpKeyword", "BCLBUILD2001");
-
-    # If the targets exist at the time the target runs, package restore ran but the build didn't import the targets.
-    $errorTask = $target.AddTask("Error")
-    $errorTask.Condition = "Exists('$relativePath') And ('`$(RunExcelDnaBuild)' != '' And `$(RunExcelDnaBuild))"
-    $errorTask.SetParameter("Text", "ExcelDna cannot be run because NuGet packages were restored prior to the build running, and the targets file was unavailable when the build started. Please build the project again to include these packages in the build. You may also need to make sure that your build server does not delete packages prior to each build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568.");
-    $errorTask.SetParameter("HelpKeyword", "BCLBUILD2002");
-
     if ($isFSharpProject)
     {
         $project.Save("")

--- a/Package/ExcelDna.AddIn/tools/uninstall.ps1
+++ b/Package/ExcelDna.AddIn/tools/uninstall.ps1
@@ -26,37 +26,13 @@ param($installPath, $toolsPath, $package, $project)
         }
     }
 
-    Write-Host "`Removing build targets from the project"
-    
-    # Need to load MSBuild assembly if it's not loaded yet
-    Add-Type -AssemblyName 'Microsoft.Build, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
-    
-    # Grab the loaded MSBuild project for the project
-    $msbuild = [Microsoft.Build.Evaluation.ProjectCollection]::GlobalProjectCollection.GetLoadedProjects($project.FullName) | Select-Object -First 1
-    
-    # Find all the imports and targets added by this package
-    $itemsToRemove = @()
-    
-    # Allow many in case a past package was incorrectly uninstalled
-    $itemsToRemove += $msbuild.Xml.Imports | Where-Object { $_.Project.EndsWith('ExcelDna.AddIn.targets') }
-    $itemsToRemove += $msbuild.Xml.Targets | Where-Object { $_.Name -eq "EnsureExcelDnaTargetsImported" }
-    
-    # Remove the elements and save the project
-    if ($itemsToRemove -and $itemsToRemove.length)
+    if ($isFSharpProject)
     {
-       foreach ($itemToRemove in $itemsToRemove)
-       {
-           $msbuild.Xml.RemoveChild($itemToRemove) | out-null
-       }
-       
-        if ($isFSharpProject)
-        {
-            $project.Save("")
-        }
-        else
-        {
-            $project.Save()
-        }
+        $project.Save("")
+    }
+    else
+    {
+        $project.Save()
     }
 
     Write-Host "Completed ExcelDna.AddIn uninstall script"


### PR DESCRIPTION
This PR improves the installation process of our `ExcelDna.AddIn` NuGet package by moving the `.targets` file to a `build` folder, [which tells NuGet to (automatically) include the targets file to the project file](https://docs.microsoft.com/en-us/nuget/create-packages/creating-a-package#including-msbuild-props-and-targets-in-a-package) as part of installing the NuGet package.

With that feature, we are able to remove most of the Powershell code that we currently have on `install.ps1` and `uninstall.ps1` to handle just that adding and removing of the `.targets` file.