### PR TITLE
Add test for App.config as linked file

### DIFF
--- a/Source/ExcelDna.AddIn.Tasks/ExcelDna.AddIn.Tasks.csproj
+++ b/Source/ExcelDna.AddIn.Tasks/ExcelDna.AddIn.Tasks.csproj
@@ -46,9 +46,6 @@
     <Compile Include="SetDebuggerOptions.cs" />
     <Compile Include="Utils\ExcelDnaProject.cs" />
     <Compile Include="Utils\IExcelDnaProject.cs" />
-    <None Include="..\..\Package\ExcelDna.AddIn\build\ExcelDna.AddIn.targets">
-      <Link>ExcelDna.AddIn.targets</Link>
-    </None>
     <None Include="Properties\ExcelDna.AddIn.Tasks.targets" />
     <Compile Include="CleanExcelAddIn.cs" />
     <Compile Include="BuildTaskCommon.cs" />
@@ -64,6 +61,10 @@
   <ItemGroup>
     <None Include="..\..\Package\ExcelDna.AddIn\content\ExcelDna.Build.props">
       <Link>ExcelDna.Build.props</Link>
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="..\..\Package\ExcelDna.AddIn\build\ExcelDna.AddIn.targets">
+      <Link>ExcelDna.AddIn.targets</Link>
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget.sln
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget.sln
@@ -23,6 +23,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharedOutDirProjectOne", "S
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharedOutDirProjectTwo", "SharedOutDirProjectTwo\SharedOutDirProjectTwo.csproj", "{C174238C-B87F-41D3-BCAA-325AB66F0A7F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SingleDnaFileAppConfigLinked", "SingleDnaFileAppConfigLinked\SingleDnaFileAppConfigLinked.csproj", "{0F73C988-703D-4812-AB59-675B25F55E1F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,8 +71,15 @@ Global
 		{C174238C-B87F-41D3-BCAA-325AB66F0A7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C174238C-B87F-41D3-BCAA-325AB66F0A7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C174238C-B87F-41D3-BCAA-325AB66F0A7F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F73C988-703D-4812-AB59-675B25F55E1F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F73C988-703D-4812-AB59-675B25F55E1F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F73C988-703D-4812-AB59-675B25F55E1F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F73C988-703D-4812-AB59-675B25F55E1F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5B32D89B-F6FC-4D5E-8156-2CBE3B014A1E}
 	EndGlobalSection
 EndGlobal

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget.sln
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27428.2043
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SingleDnaFileDefaultSuffix", "SingleDnaFileDefaultSuffix\SingleDnaFileDefaultSuffix.csproj", "{69CFC6E4-EAF6-416A-B462-B586DC3E051D}"
 EndProject

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/PreAndPostBuildEvents/PreAndPostBuildEvents.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/PreAndPostBuildEvents/PreAndPostBuildEvents.csproj
@@ -48,7 +48,7 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(ProjectDir)..\..\.exceldna.addin\tools\ExcelDna.AddIn.targets" />
+  <Import Project="$(ProjectDir)..\..\.exceldna.addin\build\ExcelDna.AddIn.targets" />
   <PropertyGroup>
     <PreBuildEvent>ECHO Running ExcelDna **Pre-build** event</PreBuildEvent>
   </PropertyGroup>

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SeparateDnaFilesCustomSuffix_x86_x64/SeparateDnaFilesCustomSuffix_x86_x64.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SeparateDnaFilesCustomSuffix_x86_x64/SeparateDnaFilesCustomSuffix_x86_x64.csproj
@@ -53,7 +53,7 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(ProjectDir)..\..\.exceldna.addin\tools\ExcelDna.AddIn.targets" />
+  <Import Project="$(ProjectDir)..\..\.exceldna.addin\build\ExcelDna.AddIn.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SeparateDnaFilesDefaultSuffix/SeparateDnaFilesDefaultSuffix.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SeparateDnaFilesDefaultSuffix/SeparateDnaFilesDefaultSuffix.csproj
@@ -53,7 +53,7 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(ProjectDir)..\..\.exceldna.addin\tools\ExcelDna.AddIn.targets" />
+  <Import Project="$(ProjectDir)..\..\.exceldna.addin\build\ExcelDna.AddIn.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SharedOutDirProjectOne/SharedOutDirProjectOne.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SharedOutDirProjectOne/SharedOutDirProjectOne.csproj
@@ -47,7 +47,7 @@
     <None Include="AddIn-One-x64.dna" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(ProjectDir)..\..\.exceldna.addin\tools\ExcelDna.AddIn.targets" />
+  <Import Project="$(ProjectDir)..\..\.exceldna.addin\build\ExcelDna.AddIn.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SharedOutDirProjectTwo/SharedOutDirProjectTwo.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SharedOutDirProjectTwo/SharedOutDirProjectTwo.csproj
@@ -51,7 +51,7 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(ProjectDir)..\..\.exceldna.addin\tools\ExcelDna.AddIn.targets" />
+  <Import Project="$(ProjectDir)..\..\.exceldna.addin\build\ExcelDna.AddIn.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileAppConfigLinked/AddIn.cs
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileAppConfigLinked/AddIn.cs
@@ -1,0 +1,21 @@
+﻿using System.IO;
+using System.Windows.Forms;
+using ExcelDna.Integration;
+
+namespace SingleDnaFileDefaultSuffix
+{
+    public class AddIn : IExcelAddIn
+    {
+        public void AutoOpen()
+        {
+            var thisAddInName = Path.GetFileName((string)XlCall.Excel(XlCall.xlGetName));
+            var message = string.Format("Excel-DNA Add-In '{0}' loaded!", thisAddInName);
+
+            MessageBox.Show(message, thisAddInName, MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+
+        public void AutoClose()
+        {
+        }
+    }
+}

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileAppConfigLinked/MyLibrary-AddIn.dna
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileAppConfigLinked/MyLibrary-AddIn.dna
@@ -1,0 +1,20 @@
+<DnaLibrary Name="SingleDnaFileAppConfigLinked Add-In" RuntimeVersion="v4.0">
+  <ExternalLibrary Path="SingleDnaFileAppConfigLinked.dll" LoadFromBytes="true" Pack="true" />
+  
+  <!-- 
+       The RuntimeVersion attribute above allows two settings:
+       * RuntimeVersion="v2.0" - for .NET 2.0, 3.0 and 3.5
+       * RuntimeVersion="v4.0" - for .NET 4 and 4.5
+
+       Additional referenced assemblies can be specified by adding 'Reference' tags. 
+       These libraries will not be examined and registered with Excel as add-in libraries, 
+       but will be packed into the -packed.xll file and loaded at runtime as needed.
+       For example:
+       
+       <Reference Path="Another.Library.dll" Pack="true" />
+  
+       Excel-DNA also allows the xml for ribbon UI extensions to be specified in the .dna file.
+       See the main Excel-DNA site at http://excel-dna.net for downloads of the full distribution.
+  -->
+
+</DnaLibrary>

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileAppConfigLinked/Properties/AssemblyInfo.cs
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileAppConfigLinked/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SingleDnaFileAppConfigLinked")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SingleDnaFileAppConfigLinked")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("0f73c988-703d-4812-ab59-675b25f55e1f")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileAppConfigLinked/SingleDnaFileAppConfigLinked.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileAppConfigLinked/SingleDnaFileAppConfigLinked.csproj
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0F73C988-703D-4812-AB59-675B25F55E1F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SingleDnaFileAppConfigLinked</RootNamespace>
+    <AssemblyName>SingleDnaFileAppConfigLinked</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="ExcelDna.Integration">
+      <HintPath>..\..\.exceldna.addin\tools\ExcelDna.Integration.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AddIn.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\SingleDnaFileDefaultSuffix\App.config">
+      <Link>App.config</Link>
+    </None>
+    <None Include="MyLibrary-AddIn.dna">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(ProjectDir)..\..\.exceldna.addin\build\ExcelDna.AddIn.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileCustomSuffix_x64/SingleDnaFileCustomSuffix_x64.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileCustomSuffix_x64/SingleDnaFileCustomSuffix_x64.csproj
@@ -49,7 +49,7 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(ProjectDir)..\..\.exceldna.addin\tools\ExcelDna.AddIn.targets" />
+  <Import Project="$(ProjectDir)..\..\.exceldna.addin\build\ExcelDna.AddIn.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileCustomSuffix_x86/SingleDnaFileCustomSuffix_x86.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileCustomSuffix_x86/SingleDnaFileCustomSuffix_x86.csproj
@@ -49,7 +49,7 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(ProjectDir)..\..\.exceldna.addin\tools\ExcelDna.AddIn.targets" />
+  <Import Project="$(ProjectDir)..\..\.exceldna.addin\build\ExcelDna.AddIn.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileDefaultSuffix/SingleDnaFileDefaultSuffix.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileDefaultSuffix/SingleDnaFileDefaultSuffix.csproj
@@ -49,7 +49,7 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(ProjectDir)..\..\.exceldna.addin\tools\ExcelDna.AddIn.targets" />
+  <Import Project="$(ProjectDir)..\..\.exceldna.addin\build\ExcelDna.AddIn.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileInSubFolderDefaultSuffix/SingleDnaFileInSubFolderDefaultSuffix.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileInSubFolderDefaultSuffix/SingleDnaFileInSubFolderDefaultSuffix.csproj
@@ -49,7 +49,7 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(ProjectDir)..\..\.exceldna.addin\tools\ExcelDna.AddIn.targets" />
+  <Import Project="$(ProjectDir)..\..\.exceldna.addin\build\ExcelDna.AddIn.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileNoConfigDefaultSuffix/SingleDnaFileNoConfigDefaultSuffix.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SingleDnaFileNoConfigDefaultSuffix/SingleDnaFileNoConfigDefaultSuffix.csproj
@@ -48,7 +48,7 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(ProjectDir)..\..\.exceldna.addin\tools\ExcelDna.AddIn.targets" />
+  <Import Project="$(ProjectDir)..\..\.exceldna.addin\build\ExcelDna.AddIn.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests/ExcelDna.AddIn.Tasks.IntegrationTests.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests/ExcelDna.AddIn.Tasks.IntegrationTests.csproj
@@ -54,6 +54,7 @@
     <Compile Include="SingleDnaFileCustomSuffix_x64IntegrationTests.cs" />
     <Compile Include="SingleDnaFileCustomSuffix_x86IntegrationTests.cs" />
     <Compile Include="SingleDnaFileDefaultSuffixIntegrationTests.cs" />
+    <Compile Include="SingleDnaFileAppConfigLinkedIntegrationTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests/SingleDnaFileAppConfigLinkedIntegrationTests.cs
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests/SingleDnaFileAppConfigLinkedIntegrationTests.cs
@@ -1,0 +1,26 @@
+﻿using NUnit.Framework;
+
+namespace ExcelDna.AddIn.Tasks.IntegrationTests
+{
+    [TestFixture]
+    public class SingleDnaFileAppConfigLinkedIntegrationTests : IntegrationTestBase
+    {
+        [Test]
+        public void A_project_with_an_app_config_added_as_link_will_generate_app_config_in_the_release_folder()
+        {
+            const string appConfigProjectBasePath = @"SingleDnaFileDefaultSuffix\";
+            const string projectBasePath = @"SingleDnaFileAppConfigLinked\";
+            const string projectOutDir = projectBasePath + @"bin\Release\";
+
+            Clean(projectOutDir);
+
+            MsBuild(projectBasePath + "SingleDnaFileAppConfigLinked.csproj /t:Build /p:Configuration=Release /v:m " + MsBuildParam("OutputPath", @"bin\Release\"));
+
+            AssertIdentical(appConfigProjectBasePath + "App.config", projectOutDir + "MyLibrary-AddIn.xll.config");
+            AssertIdentical(appConfigProjectBasePath + "App.config", projectOutDir + "MyLibrary-AddIn-packed.xll.config");
+
+            AssertIdentical(appConfigProjectBasePath + "App.config", projectOutDir + "MyLibrary-AddIn64.xll.config");
+            AssertIdentical(appConfigProjectBasePath + "App.config", projectOutDir + "MyLibrary-AddIn64-packed.xll.config");
+        }
+    }
+}


### PR DESCRIPTION
Add test to validate [Building an Excel DNA addin doesn't find app.config when added to a project as a link #177](https://github.com/Excel-DNA/ExcelDna/issues/177)

![image](https://user-images.githubusercontent.com/177608/39659351-e76e4f88-4ffc-11e8-9beb-41e6937b8427.png)
