### PR TITLE
Ask user to restart Visual Studio when `SetDebuggerOptions` fails to run

### DIFF
--- a/Source/ExcelDna.AddIn.Tasks/SetDebuggerOptions.cs
+++ b/Source/ExcelDna.AddIn.Tasks/SetDebuggerOptions.cs
@@ -50,7 +50,7 @@ namespace ExcelDna.AddIn.Tasks
 
                 if (!_dte.TrySetDebuggerOptions(ProjectName, excelExePath, addInForDebugging, msg => LogDebugMessage(msg)))
                 {
-                    LogWarning("DNA" + "DTE".GetHashCode(), "Unable to set the debugger options within Visual Studio.");
+                    LogWarning("DNA" + "DTE".GetHashCode(), "Unable to set the debugger options within Visual Studio. Please restart Visual Studio and try again.");
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
Related to #181 