### PR TITLE
Add initial .editorconfig file

### DIFF
--- a/Source/.editorconfig
+++ b/Source/.editorconfig
@@ -1,0 +1,23 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = crlf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.{proj,props,sln,targets}]
+indent_style = tab
+
+[*.{dna,config,nuspec,asm,csproj,vcxproj,vcproj,targets,ps1,resx}]
+indent_size = 2
+
+[*.{cpp,h,def}]
+indent_style = tab
+
+[*.{dotsettings}]
+end_of_line = lf


### PR DESCRIPTION
Add an [`.editorconfig`](http://editorconfig.org) file to help us keep a consistent coding style between different editors and IDEs. VS2017 differs in style with prior versions, and some of our files are getting messy with mixed tabs and spaces which makes it harder to diff changes