### PR TITLE
Add Source Code Link for all NuGet packages

### DIFF
--- a/Package/Excel-DNA.Lib/Excel-DNA.Lib.nuspec
+++ b/Package/Excel-DNA.Lib/Excel-DNA.Lib.nuspec
@@ -7,6 +7,7 @@
         <authors>Govert van Drimmelen</authors>
         <owners>Govert van Drimmelen</owners>
         <projectUrl>http://excel-dna.net</projectUrl>
+        <repository type="git" url="https://github.com/Excel-DNA/ExcelDna" />
         <iconUrl>http://docs.excel-dna.net/NuGetIcon.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Deprecated reference library package for Excel-DNA. Use the package ExcelDna.AddIn to create a new add-in. Use the package ExcelDna.Integration to only reference the integration library.</description>

--- a/Package/Excel-DNA/Excel-DNA.nuspec
+++ b/Package/Excel-DNA/Excel-DNA.nuspec
@@ -7,6 +7,7 @@
         <authors>Govert van Drimmelen</authors>
         <owners>Govert van Drimmelen</owners>
         <projectUrl>http://excel-dna.net</projectUrl>
+        <repository type="git" url="https://github.com/Excel-DNA/ExcelDna" />
         <iconUrl>http://docs.excel-dna.net/NuGetIcon.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>This NuGet package is deprecated, and used for compatibility only. The basic Excel-DNA NuGet package is now called ExcelDna.AddIn.</description>

--- a/Package/ExcelDna.AddIn/ExcelDna.AddIn.nuspec
+++ b/Package/ExcelDna.AddIn/ExcelDna.AddIn.nuspec
@@ -7,6 +7,7 @@
         <authors>Govert van Drimmelen</authors>
         <owners>Govert van Drimmelen</owners>
         <projectUrl>http://excel-dna.net</projectUrl>
+        <repository type="git" url="https://github.com/Excel-DNA/ExcelDna" />
         <iconUrl>http://docs.excel-dna.net/NuGetIcon.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Excel-DNA eases the development of Excel add-ins using .NET. 

--- a/Package/ExcelDna.Integration/ExcelDna.Integration.nuspec
+++ b/Package/ExcelDna.Integration/ExcelDna.Integration.nuspec
@@ -7,6 +7,7 @@
         <authors>Govert van Drimmelen</authors>
         <owners>Govert van Drimmelen</owners>
         <projectUrl>http://excel-dna.net</projectUrl>
+        <repository type="git" url="https://github.com/Excel-DNA/ExcelDna" />
         <iconUrl>http://docs.excel-dna.net/NuGetIcon.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Reference library package for Excel-DNA. Use the package "ExcelDna.AddIn" to create a new add-in.</description>

--- a/Package/ExcelDna.XmlSchemas/ExcelDna.XmlSchemas.nuspec
+++ b/Package/ExcelDna.XmlSchemas/ExcelDna.XmlSchemas.nuspec
@@ -7,6 +7,7 @@
     <authors>Excel-DNA Contributors</authors>
     <owners>exceldna</owners>
     <projectUrl>http://excel-dna.net</projectUrl>
+    <repository type="git" url="https://github.com/Excel-DNA/ExcelDna" />
     <iconUrl>http://docs.excel-dna.net/NuGetIcon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>This package contains XSD files that enables IntelliSense and validation when editing `.dna` files, for example, in Visual Studio.</description>


### PR DESCRIPTION
This PR adds the `repository` element to the `.nuspec` files so that a link to this repo is displayed at nuget.org, as per [described in this post](https://blog.nuget.org/20180827/Introducing-Source-Code-Link-for-NuGet-packages.html).

![image](https://user-images.githubusercontent.com/177608/54481517-407d2580-4814-11e9-98bc-a4faab0e0c21.png)
