### PR TITLE
Add `ExcelIntegration.UnhandledException` event

### DIFF
--- a/Source/ExcelDna.Integration/ExcelIntegration.cs
+++ b/Source/ExcelDna.Integration/ExcelIntegration.cs
@@ -33,6 +33,8 @@ namespace ExcelDna.Integration
 
         private static TryExcelImplDelegate tryExcelImpl;
 
+        private static readonly object _syncLock = new object();
+
         [UsedImplicitly] // called by reflection
         internal static void SetTryExcelImpl(TryExcelImplDelegate d)
         {
@@ -116,11 +118,42 @@ namespace ExcelDna.Integration
             }
         }
 
-		private static UnhandledExceptionHandler unhandledExceptionHandler;
-		public static void RegisterUnhandledExceptionHandler(UnhandledExceptionHandler h)
-		{
-			unhandledExceptionHandler = h;
-		}
+        private static UnhandledExceptionHandler unhandledExceptionHandler;
+
+        public static event UnhandledExceptionHandler UnhandledException
+        {
+            add
+            {
+                if (value == null)
+                {
+                    return;
+                }
+
+                lock (_syncLock)
+                {
+                    unhandledExceptionHandler += value;
+                }
+            }
+
+            remove
+            {
+                if (value == null)
+                {
+                    return;
+                }
+
+                lock (_syncLock)
+                {
+                    unhandledExceptionHandler -= value;
+                }
+            }
+        }
+
+        [Obsolete("This method is obsolete. Use the `UnhandledException` event instead.")]
+        public static void RegisterUnhandledExceptionHandler(UnhandledExceptionHandler h)
+        {
+            UnhandledException += h;
+        }
 
         public static UnhandledExceptionHandler GetRegisterUnhandledExceptionHandler()
         {

--- a/Source/ExcelDna.Loader/XlAddIn.cs
+++ b/Source/ExcelDna.Loader/XlAddIn.cs
@@ -219,6 +219,15 @@ namespace ExcelDna.Loader
         {
             // Get the assembly and ExcelIntegration type - will be loaded from file or from packed resources via AssemblyManager.AssemblyResolve.
             Assembly integrationAssembly = Assembly.Load("ExcelDna.Integration");
+
+            // Check if ExcelDna.Integration was loaded from the Global Assembly Cache
+            if (integrationAssembly.GlobalAssemblyCache)
+            {
+                // Prevent using the version in the GAC to avoid add-ins using the wrong version and breaking
+                // https://github.com/Excel-DNA/ExcelDna/pull/250#issuecomment-508642133
+                throw new InvalidOperationException("ExcelDna.Integration was loaded from Global Assembly Cache, and that's not allowed.");
+            }
+
             Type integrationType = integrationAssembly.GetType("ExcelDna.Integration.ExcelIntegration");
 
             // Check the version declared in the ExcelIntegration class


### PR DESCRIPTION
TL;DR; This PR adds an event called `UnhandledException` to `ExcelIntegration`, as a soft replacement to `ExcelIntegration.RegisterUnhandledExceptionHandler` (now marked as obsolete).

---

We can currently catch unhandled exceptions that are thrown from within Excel-DNA functions or macros by calling `ExcelIntegration.RegisterUnhandledExceptionHandler`:

```csharp
ExcelIntegration.RegisterUnhandledExceptionHandler(ExcelDnaUnhandledException);
```

This PR adds the ability to register handlers via an event, instead of being a method call, which is more natural and aligns with the way these handlers are registered in regular .NET apps... For example:

```
// Any app
AppDomain.CurrentDomain.UnhandledException += AppDomainUnhandledException;
TaskScheduler.UnobservedTaskException += TaskSchedulerUnobservedTaskException;

// WinForms apps
Application.ThreadException += ApplicationThreadUnhandledException;

// WPF apps
Dispatcher.CurrentDispatcher.UnhandledException += DispatchedUnhandledException;
```

---

### Usage:

```csharp
public class MyExcelAddIn : IExcelAddIn
{
    public void AutoOpen()
    {
        ExcelIntegration.UnhandledException += ExcelDnaUnhandledException;
        // ...
    }

    public void AutoClose()
    {
        // ...
    }

    private object ExcelDnaUnhandledException(object exceptionObject)
    {
        // ...
        return "Sorry!";
    }
}
```

---

This PR doesn't introduce any breaking changes. Ideas/improvements we could consider in the future (which would introduce breaking changes):

* Modify the delegate signature to have an `EventArgs` argument with a property that specify the source of the exception (Function, Macro, etc.)
* Modify the delegate signature to have an `EventArgs` argument with a property that holds the return value (and modify the delegate return type to `void`) for cases where multiple event handlers are registered and can access/modify values written by previous handlers
* Modify the delegate signature to have an `EventArgs` argument with a property that indicates if the exception was handled or not (and let it bubble up if not)