### PR TITLE
Display error message to user if project is using NuGet PackageReference

### DIFF
--- a/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
+++ b/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
@@ -61,6 +61,14 @@
   </PropertyGroup>
 
   <!--
+    Target that checks if the project is not compatible with Excel-DNA
+  -->
+  <Target Name="ExcelDnaCheckPackageProjectStyle" BeforeTargets="CoreCompile">
+    <Error Text="Excel-DNA is not compatible with projects that use NuGet `PackageReference`. Make sure you create a .NET Framework (Class Library) project and configure Visual Studio to use `packages.config`"
+           Condition=" '$(PackageReferenceCompatibleProjectStyle)' == 'true' OR '$(RestoreProjectStyle)' == 'ProjectJson' OR '$(NuGetProjectStyle)' == 'PackageReference' " />
+  </Target>
+
+  <!--
     Configure debugger options (Path for EXCEL.EXE, add-in to open, etc).
   -->
   <Target Name="ExcelDnaSetDebuggerOptions" BeforeTargets="PreBuildEvent" Condition="$(RunExcelDnaSetDebuggerOptions) AND '$(BuildingInsideVisualStudio)' == 'true'">


### PR DESCRIPTION
We've been receiving an increasing number of support requests from users that create projects that use the `PackageReference` style, which is not compatible with Excel-DNA as of this writing (#138).

This PR detects if the Excel-DNA add-in project is using the `PackageReference` style and displays an error message during build, with instructions on how to resolve the issue:

> Excel-DNA is not compatible with projects that use NuGet `PackageReference`. Make sure you create a .NET Framework (Class Library) project and configure Visual Studio to use `packages.config`

![image](https://user-images.githubusercontent.com/177608/67541309-df2d0700-f6be-11e9-9786-3de45825901d.png)

The error message above is displayed just before compilation starts, when:
* The user created a `Class Library (.NET Standard)` project (a.k.a. SDK-style project)
* The user created a `Class Library (.NET Framework)` project, but uses the `PackageReference` style instead of `packages.config`

---

Related links:

* [ExcelDna.AddIn NuGet package installation fails as a PackageReference](https://github.com/Excel-DNA/ExcelDna/issues/138)
* [After enabling PackageReference support for projects, some packages may not install or work correctly](https://github.com/NuGet/Home/issues/4942)
* [Unable to find add-in to Debug](https://groups.google.com/d/topic/exceldna/iPhmF2cOvw8/discussion)
* [Error installing Excel-DNA package in VS2017](https://groups.google.com/d/topic/exceldna/qNXRhCwpuzg/discussion)
* [<project>-AddIn.dna and .xlls not being created on NuGet install](https://groups.google.com/d/topic/exceldna/mgkk_t5t5Uw/discussion)
* [Visual Studio Community 2017 Preview](https://groups.google.com/d/topic/exceldna/GOqEBI6aiUI/discussion)
* [Unable to find add-in to Debug](https://groups.google.com/d/topic/exceldna/iPhmF2cOvw8/discussion)
* [VS 2017 doesn't execute install.ps1 from packages if used as PackageReference](https://github.com/NuGet/Home/issues/6330)
* [packages.config (PC) to PackageReference (PR) Migration](https://github.com/NuGet/Home/issues/5877)
* [I was asked to list some pain points to updating to PackageReference](https://github.com/NuGet/Home/issues/5990)
