### PR TITLE
Expose `ManagedThreadId` of thread where the add-in was loaded

### DIFF
--- a/Source/ExcelDna.Integration/Excel.cs
+++ b/Source/ExcelDna.Integration/Excel.cs
@@ -70,6 +70,11 @@ namespace ExcelDna.Integration
             }
         }
 
+        public static int MainManagedThreadId
+        {
+            get { return _mainManagedThreadId; }
+        }
+
         #region Get Window Handle
         // NOTE: Careful not to call ExcelVersion here - might recurse causing StackOverflow
 


### PR DESCRIPTION
Relates to #265. Allows developers to get access to the `ManagedThreadId` where the Excel-DNA Add-in was loaded from, so they can determine if it's safe to make COM calls or not.