### PR TITLE
Check if Application is cached before `GetApplicationFromWindows`

### DIFF
--- a/Source/ExcelDna.Integration/Excel.cs
+++ b/Source/ExcelDna.Integration/Excel.cs
@@ -229,9 +229,12 @@ namespace ExcelDna.Integration
                             "Cross-thread operation not valid: Application accessed from a thread other than the thread it was created on.");
                     }
 
-                    // Nothing cached - possibly being called on a different thread
-                    // Just get from window and return
-                    return GetApplicationFromWindows(true, out isProtected);
+                    if (_application == null)
+                    {
+                        // Nothing cached - possibly being called on a different thread
+                        // Just get from window and return
+                        return GetApplicationFromWindows(true, out isProtected);
+                    }
                 }
 
                 // Check whether we have a cached App and it is valid


### PR DESCRIPTION
I'm might have missed something here (correct me if I did), but from reading the code and comments, my understanding is that there used to be a reason to assume that if `ExcelDnaUtil.Application` was being called from a non-UI thread, then it would be impossible for it to be cached already (from a previous call on the UI thread), because of `ThreadStatic` - but this is no longer the case.

This lets the code continue the execution flow (with a call to `IsApplicationOK`) if a previous call to `Application` succeeded, rather than trying to `GetApplicationFromWindows`, just because it's a non-UI thread.
