### PR TITLE
Tell NuGet that `ExcelDna.AddIn` is a DevDependency (for PackageReference compat)

### DIFF
--- a/Package/ExcelDna.AddIn/ExcelDna.AddIn.nuspec
+++ b/Package/ExcelDna.AddIn/ExcelDna.AddIn.nuspec
@@ -21,9 +21,10 @@
     The Excel-Dna Runtime is free for all use, and distributed under a permissive open-source license that also allows commercial use.</description>
         <summary>Excel-DNA is an independent project to integrate .NET into Excel.</summary>
         <tags>excel exceldna udf excel-dna</tags>
-            <dependencies>
-      <dependency id="ExcelDna.Integration" version="[1.0.0]" />
-    </dependencies>
+        <developmentDependency>true</developmentDependency>
+        <dependencies>
+          <dependency id="ExcelDna.Integration" version="[1.0.0]" />
+        </dependencies>
     </metadata>
     <files>
         <file src="..\..\Distribution\ExcelDna.Integration.dll" target="tools\ExcelDna.Integration.dll" />


### PR DESCRIPTION
Tiny step towards `PackageReference` support. Tell dotnet publish to not include `ExcelDna.AddIn` as a dependency of the add-in being developed.

---

Relates to #188, #189, #193