### PR TITLE
Add `XllPathInfo` property to `ExcelDnaUtil`

### DIFF
--- a/Source/ExcelDna.Integration/DnaLibrary.cs
+++ b/Source/ExcelDna.Integration/DnaLibrary.cs
@@ -50,6 +50,16 @@ namespace ExcelDna.Integration
             }
         }
 
+        private static FileInfo _xllPathPathInfo;
+        [XmlIgnore]
+        internal static FileInfo XllPathInfo
+        {
+            get
+            {
+                return _xllPathPathInfo;
+            }
+        }
+
         private string _Name;
         [XmlAttribute]
         public string Name
@@ -408,6 +418,7 @@ namespace ExcelDna.Integration
 
             // CAREFUL: Sequence here is fragile - this is the first place where we start logging
             _XllPath = xllPath;
+            _xllPathPathInfo = new FileInfo(xllPath);
             Logging.LogDisplay.CreateInstance();
             Logger.Initialization.Verbose("Enter DnaLibrary.InitializeRootLibrary");
             byte[] dnaBytes = ExcelIntegration.GetDnaFileBytes("__MAIN__");

--- a/Source/ExcelDna.Integration/Excel.cs
+++ b/Source/ExcelDna.Integration/Excel.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Reflection;
 
 namespace ExcelDna.Integration
@@ -679,6 +680,14 @@ namespace ExcelDna.Integration
             get
             {
                 return DnaLibrary.XllPath;
+            }
+        }
+
+        public static FileInfo XllPathInfo
+        {
+            get
+            {
+                return DnaLibrary.XllPathInfo;
             }
         }
 


### PR DESCRIPTION
This PR adds a property called `XllPathInfo` to `ExcelDnaUtil` of type `System.IO.FileInfo`. I'm thinking that most of the time, when add-in developers use the property `XllPath`, they are interested in getting the **folder** where the `.xll` is located, in order to access a file that is located on the same folder as the `.xll`.

`XllPathInfo` then becomes an alternative to `XllPath` that also includes a `DirectoryName` property for easy access of the add-in install folder, allowing this:

```csharp
var xllPath = ExcelDnaUtil.XllPath;
var xllFolder = Path.GetDirectoryName(xllPath);
var excelFilePath = Path.Combine(xllFolder, "File.xlsx");
```

To to become this:

```csharp
var excelFilePath = Path.Combine(ExcelDnaUtil.XllPathInfo.DirectoryName, "File.xlsx");
```

---

I'm open to ideas...

- Is `XllPathInfo` a good choice of name? Should we use a longer name like `XllPathFileInfo`?
- Should we go for `XllDirectoryInfo` (or diff name) instead, returning a `DirectoryInfo` instead of `FileInfo`, therefore exposing the installation folder specifically? Why is that better?
