### PR TITLE
Improve ExcelDna.Integration `CopyLocal=false` story

### DIFF
--- a/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
+++ b/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
@@ -69,6 +69,17 @@
   </Target>
 
   <!--
+    Target that ensures ExcelDna.Integration.dll is not copied to the output folder
+    https://github.com/Excel-DNA/ExcelDna/issues/188
+  -->
+  <Target Name="ExcelDnaPreventIntegrationCopyLocal" AfterTargets="ResolveAssemblyReferences">
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
+                               Condition="'%(ReferenceCopyLocalPaths.Filename)%(ReferenceCopyLocalPaths.Extension)' == 'ExcelDna.Integration.dll'" />
+    </ItemGroup>
+  </Target>
+
+  <!--
     Configure debugger options (Path for EXCEL.EXE, add-in to open, etc).
   -->
   <Target Name="ExcelDnaSetDebuggerOptions" BeforeTargets="PreBuildEvent" Condition="$(RunExcelDnaSetDebuggerOptions) AND '$(BuildingInsideVisualStudio)' == 'true'">

--- a/Package/ExcelDna.Integration/ExcelDna.Integration.nuspec
+++ b/Package/ExcelDna.Integration/ExcelDna.Integration.nuspec
@@ -16,6 +16,5 @@
     </metadata>
     <files>
         <file src="..\..\Distribution\ExcelDna.Integration.dll" target="lib\ExcelDna.Integration.dll" />
-        <file src="tools\install.ps1" target="tools\install.ps1" />
     </files>
 </package>

--- a/Package/ExcelDna.Integration/tools/install.ps1
+++ b/Package/ExcelDna.Integration/tools/install.ps1
@@ -1,7 +1,0 @@
-param($installPath, $toolsPath, $package, $project)
-Write-Host "Starting ExcelDna.Integration install script"
-
-Write-Host "`tSet reference to ExcelDna.Integration to be CopyLocal=false"
-$project.Object.References | Where-Object { $_.Name -eq 'ExcelDna.Integration' } | ForEach-Object { $_.CopyLocal = $false }
-
-Write-Host "Completed ExcelDna.Integration install script"


### PR DESCRIPTION
Add a build target in the `ExcelDna.AddIn` build process that ensures `ExcelDna.Integration.dll` is **not** copied to the output folder, effectively removing the need for setting `CopyLocal=false` on Excel-DNA Add-in projects.

This also removes the need for the `install.ps1` in the `ExcelDna.Integration` NuGet package.

Resolves #188