### PR TITLE
Display warning (instead of error) for SDK-style projects

### DIFF
--- a/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
+++ b/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
@@ -64,8 +64,9 @@
     Target that checks if the project is not compatible with Excel-DNA
   -->
   <Target Name="ExcelDnaCheckPackageProjectStyle" BeforeTargets="CoreCompile">
-    <Error Text="Excel-DNA is not compatible with projects that use NuGet `PackageReference`. Make sure you create a .NET Framework (Class Library) project and configure Visual Studio to use `packages.config`"
-           Condition=" '$(PackageReferenceCompatibleProjectStyle)' == 'true' OR '$(RestoreProjectStyle)' == 'ProjectJson' OR '$(NuGetProjectStyle)' == 'PackageReference' " />
+    <Warning Code="DNA1546"
+             Text="Excel-DNA is not compatible with projects that use NuGet `PackageReference`. Make sure you create a .NET Framework (Class Library) project and configure Visual Studio to use `packages.config`"
+             Condition=" '$(PackageReferenceCompatibleProjectStyle)' == 'true' OR '$(RestoreProjectStyle)' == 'ProjectJson' OR '$(NuGetProjectStyle)' == 'PackageReference' " />
   </Target>
 
   <!--


### PR DESCRIPTION
Change the check for SDK-style project compatibility to a warning instead of an error, with the ability to be suppressed, for devs that can work around the current limitations of SDK-style projects with Excel-DNA.