### PR TITLE
Allow devs to use PackageReference if they wish (despite current limitations)

### DIFF
--- a/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
+++ b/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
@@ -54,6 +54,8 @@
     <ExcelDna32BitAddInSuffix Condition="'$(ExcelDna32BitAddInSuffix)' == ''"></ExcelDna32BitAddInSuffix>
     <ExcelDna64BitAddInSuffix Condition="'$(ExcelDna64BitAddInSuffix)' == ''">64</ExcelDna64BitAddInSuffix>
 
+    <ExcelDnaAllowPackageReferenceProjectStyle Condition="'$(ExcelDnaAllowPackageReferenceProjectStyle)' == ''">false</ExcelDnaAllowPackageReferenceProjectStyle>
+
     <ExcelDnaPackExePath Condition="'$(ExcelDnaPackExePath)' == ''">$(ExcelDnaToolsPath)ExcelDnaPack.exe</ExcelDnaPackExePath>
     <ExcelDnaPackXllSuffix Condition="'$(ExcelDnaPackXllSuffix)' == ''">-packed</ExcelDnaPackXllSuffix>
     <ExcelDnaPackCompressResources Condition="'$(ExcelDnaPackCompressResources)' == ''">true</ExcelDnaPackCompressResources>
@@ -64,9 +66,9 @@
     Target that checks if the project is not compatible with Excel-DNA
   -->
   <Target Name="ExcelDnaCheckPackageProjectStyle" BeforeTargets="CoreCompile">
-    <Warning Code="DNA1546"
-             Text="Excel-DNA is not compatible with projects that use NuGet `PackageReference`. Make sure you create a .NET Framework (Class Library) project and configure Visual Studio to use `packages.config`"
-             Condition=" '$(PackageReferenceCompatibleProjectStyle)' == 'true' OR '$(RestoreProjectStyle)' == 'ProjectJson' OR '$(NuGetProjectStyle)' == 'PackageReference' " />
+    <Error Code="DNA1546"
+           Text="Excel-DNA is not compatible with projects that use NuGet `PackageReference`. Make sure you create a .NET Framework (Class Library) project and configure Visual Studio to use `packages.config`"
+           Condition=" '$(ExcelDnaAllowPackageReferenceProjectStyle)' != 'true' AND ('$(PackageReferenceCompatibleProjectStyle)' == 'true' OR '$(RestoreProjectStyle)' == 'ProjectJson' OR '$(NuGetProjectStyle)' == 'PackageReference') " />
   </Target>
 
   <!--

--- a/Package/ExcelDna.AddIn/content/ExcelDna.Build.props
+++ b/Package/ExcelDna.AddIn/content/ExcelDna.Build.props
@@ -52,6 +52,13 @@
     <ExcelDna64BitAddInSuffix Condition="'$(ExcelDna64BitAddInSuffix)' == ''">64</ExcelDna64BitAddInSuffix>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!--
+      Enable/Disable using Excel-DNA with PackageReference projects (not officially supported)
+    -->
+    <ExcelDnaAllowPackageReferenceProjectStyle Condition="'$(ExcelDnaAllowPackageReferenceProjectStyle)' == ''">false</ExcelDnaAllowPackageReferenceProjectStyle>
+  </PropertyGroup>
+
   <!--
     Configuration properties for packing .dna files
   -->


### PR DESCRIPTION
- Add new build parameter `ExcelDnaAllowPackageReferenceProjectStyle` to the `.props` file (defaults to `false`) to allow for displaying error when users install `ExcelDna.AddIn` on projects that use the `PackageReference` style
- Changing the parameter to `true` allows the developer to bypass the error, if the wish to use `PackageReference` with a workaround for copying the files, etc.