### PR TITLE
Set PlatformTarget to x86 for Release builds & also Prefer32Bit for both Debug and Release

### DIFF
--- a/Source/ExcelDnaPack/ExcelDnaPack.csproj
+++ b/Source/ExcelDnaPack/ExcelDnaPack.csproj
@@ -32,7 +32,7 @@
     <LangVersion>3</LangVersion>
     <PlatformTarget>x86</PlatformTarget>
     <UseVSHostingProcess>true</UseVSHostingProcess>
-    <Prefer32Bit>false</Prefer32Bit>
+    <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -43,7 +43,8 @@
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>3</LangVersion>
-    <Prefer32Bit>false</Prefer32Bit>
+    <PlatformTarget>x86</PlatformTarget>
+    <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
I noticed only `Debug` builds had the `PlatformTarget` set to `x86`.

Also setting `Prefer32Bit` to `true` for consistency.

Once we add ExcelDnaPack as a build task, we can add test coverage for x64 and make sure it works as expected.