### PR TITLE
Remove v2.0 as an option on the RuntimeVersion attribute of the .dna schema

### DIFF
--- a/Distribution/XmlSchemas/ExcelDna.DnaLibrary.xsd
+++ b/Distribution/XmlSchemas/ExcelDna.DnaLibrary.xsd
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xs:schema id="dna"
-           targetNamespace="http://schemas.excel-dna.net/addin/2018/05/dnalibrary"
+           targetNamespace="http://schemas.excel-dna.net/addin/2020/07/dnalibrary"
            attributeFormDefault="unqualified"
            elementFormDefault="qualified"
-           xmlns="http://schemas.excel-dna.net/addin/2018/05/dnalibrary"
-           xmlns:mstns="http://schemas.excel-dna.net/addin/2018/05/dnalibrary"
+           xmlns="http://schemas.excel-dna.net/addin/2020/07/dnalibrary"
+           xmlns:mstns="http://schemas.excel-dna.net/addin/2020/07/dnalibrary"
            xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:simpleType name="Boolean">
@@ -33,14 +33,12 @@
       <xs:simpleType>
         <!-- Intellisense suggestions -->
         <xs:restriction base="xs:string">
-          <xs:enumeration value="v2.0" />
           <xs:enumeration value="v4.0" />
         </xs:restriction>
       </xs:simpleType>
       <xs:simpleType>
         <!-- Other allowed values (but hidden from Intellisense) -->
         <xs:restriction base="xs:string">
-          <xs:pattern value="v2.0.50727" />
           <xs:pattern value="v4.0.30319" />
         </xs:restriction>
       </xs:simpleType>

--- a/Distribution/XmlSchemas/ExcelDnaCatalog.xml
+++ b/Distribution/XmlSchemas/ExcelDnaCatalog.xml
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <SchemaCatalog xmlns="http://schemas.microsoft.com/xsd/catalog">
-  <Association extension="dna" schema="%InstallRoot%/xml/schemas/ExcelDna.DnaLibrary.xsd" defaultNamespace="http://schemas.excel-dna.net/addin/2018/05/dnalibrary" enableValidation="true" />
+  <Association extension="dna" schema="%InstallRoot%/xml/schemas/ExcelDna.DnaLibrary.xsd" defaultNamespace="http://schemas.excel-dna.net/addin/2020/07/dnalibrary" enableValidation="true" />
 </SchemaCatalog>

--- a/Distribution/XmlSchemas/Readme.md
+++ b/Distribution/XmlSchemas/Readme.md
@@ -35,11 +35,11 @@ There are different ways you can get IntelliSense and validation for Excel-DNA A
 
     This package will add the 3 (three) XML Schema Definition files described above ([`ExcelDna.DnaLibrary.xsd`][dna-xsd], [`customUI.xsd`][cui-2007-xsd], and [`customui14.xsd`][cui-2010-xsd]) which Visual Studio will use to validate and provide IntelliSense to your `.dna` files and `.xml` files for Office Custom UI Ribbons, CTPs, etc.
 
-2. Add the XML namespace `http://schemas.excel-dna.net/addin/2018/05/dnalibrary` to your `.dna` file(s). E.g.:
+2. Add the XML namespace `http://schemas.excel-dna.net/addin/2020/07/dnalibrary` to your `.dna` file(s). E.g.:
 
     ```xml
     <?xml version="1.0" encoding="utf-8"?>
-    <DnaLibrary Name="Your Add-In" RuntimeVersion="v4.0" xmlns="http://schemas.excel-dna.net/addin/2018/05/dnalibrary">
+    <DnaLibrary Name="Your Add-In" RuntimeVersion="v4.0" xmlns="http://schemas.excel-dna.net/addin/2020/07/dnalibrary">
       <!-- (...) -->
     </DnaLibrary>
     ```
@@ -54,11 +54,11 @@ There are different ways you can get IntelliSense and validation for Excel-DNA A
 
 2. Add these files to your Excel-DNA Add-In project or solution, so that Visual Studio can detect them to perform validation and provide IntelliSense to your `.dna` files and `.xml` files for Office Custom UI Ribbons, CTPs, etc.
 
-3. Add the XML namespace `http://schemas.excel-dna.net/addin/2018/05/dnalibrary` to your `.dna` file(s). E.g.:
+3. Add the XML namespace `http://schemas.excel-dna.net/addin/2020/07/dnalibrary` to your `.dna` file(s). E.g.:
 
     ```xml
     <?xml version="1.0" encoding="utf-8"?>
-    <DnaLibrary Name="Your Add-In" RuntimeVersion="v4.0" xmlns="http://schemas.excel-dna.net/addin/2018/05/dnalibrary">
+    <DnaLibrary Name="Your Add-In" RuntimeVersion="v4.0" xmlns="http://schemas.excel-dna.net/addin/2020/07/dnalibrary">
       <!-- (...) -->
     </DnaLibrary>
     ```
@@ -83,7 +83,7 @@ In the instructions below, `%ProgramFiles(x86)%` is used to refer to the `Progra
 
     For more detailed information about [Visual Studio's Schema Cache][vs-schema-cache], see the documentation on Microsoft's website: [https://docs.microsoft.com/en-us/visualstudio/xml-tools/schema-cache][vs-schema-cache]
 
-3. IntelliSense and validation should now work for all `.dna` files you open, automatically, even if they don't have the XML namespace for `.dna` files (`http://schemas.excel-dna.net/addin/2018/05/dnalibrary`) declared (although it a good practice to always include the XML namespace on your files). If it doesn't work, try restarting any open instances of Visual Studio and try again.
+3. IntelliSense and validation should now work for all `.dna` files you open, automatically, even if they don't have the XML namespace for `.dna` files (`http://schemas.excel-dna.net/addin/2020/07/dnalibrary`) declared (although it a good practice to always include the XML namespace on your files). If it doesn't work, try restarting any open instances of Visual Studio and try again.
 
 NOTE: Updates to Visual Studio may reset the global schema cache, undoing the changes made above. If that happens and you no longer see IntelliSense for `.dna` files, you'll need to repeat the steps above. Also, remember that other developers working on your project will not have IntelliSense or validation on their machines, unless they also perform the manual steps outlined above.
 

--- a/Package/ExcelDna.XmlSchemas/ExcelDna.XmlSchemas.nuspec
+++ b/Package/ExcelDna.XmlSchemas/ExcelDna.XmlSchemas.nuspec
@@ -6,9 +6,9 @@
     <title>Excel-DNA XML Schemas</title>
     <authors>Excel-DNA Contributors</authors>
     <owners>exceldna</owners>
-    <projectUrl>http://excel-dna.net</projectUrl>
+    <projectUrl>https://excel-dna.net</projectUrl>
     <repository type="git" url="https://github.com/Excel-DNA/ExcelDna" />
-    <iconUrl>http://docs.excel-dna.net/NuGetIcon.png</iconUrl>
+    <iconUrl>https://docs.excel-dna.net/NuGetIcon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>This package contains XSD files that enables IntelliSense and validation when editing `.dna` files, for example, in Visual Studio.</description>
     <summary>XSD files for IntelliSense and validation of `.dna` files.</summary>


### PR DESCRIPTION
- RuntimeVersion now only accepts v2.0 in the .dna schema (still valid in the .xll C++ code)
- Bump version of the XSD schema `http://schemas.excel-dna.net/addin/2020/07/dnalibrary`