### PR TITLE
Update SetDebuggerOptions to open Excel in a new process when debugging

### DIFF
--- a/Source/ExcelDna.AddIn.Tasks/Utils/ExcelDnaProject.cs
+++ b/Source/ExcelDna.AddIn.Tasks/Utils/ExcelDnaProject.cs
@@ -35,7 +35,7 @@ namespace ExcelDna.AddIn.Tasks.Utils
 
                     startAction.Value = 1; // Start external program
                     startProgram.Value = excelExePath;
-                    startArguments.Value = $@"""{Path.GetFileName(excelAddInToDebug)}""";
+                    startArguments.Value = $@"/x ""{Path.GetFileName(excelAddInToDebug)}""";
 
                     project.Save(string.Empty);
 


### PR DESCRIPTION
As discussed, this PR ensures that Visual Studio will always open a new `EXCEL.exe` process when the project is run with or without debugging...