### PR TITLE
Use absolute paths when packing files in ExcelDnaPack

### DIFF
--- a/Source/ExcelDnaPack/PackProgram.cs
+++ b/Source/ExcelDnaPack/PackProgram.cs
@@ -76,7 +76,7 @@ Other assemblies are packed if marked with Pack=""true"" in the .dna file.
 				return;
 			}
 
-			string dnaPath = args[0];
+			string dnaPath = Path.GetFullPath(args[0]);
 			string dnaDirectory = Path.GetDirectoryName(dnaPath);
 //			string dnaFileName = Path.GetFileName(dnaPath);
 			string dnaFilePrefix = Path.GetFileNameWithoutExtension(dnaPath);


### PR DESCRIPTION
Expand relative paths to absolute paths to avoid issues with calling Windows APIs in some environments (e.g. Azure Pipelines) as reported in https://github.com/Excel-DNA/ExcelDna/issues/311#issuecomment-614449190.

---

Resolves #311