### PR TITLE
Addin.Task is compatible with net5.0-windows

### DIFF
--- a/Build/build.bat
+++ b/Build/build.bat
@@ -3,6 +3,10 @@ copy /Y ..\Source\ExcelDna\Release64\ExcelDna64.xll ..\Distribution\
 copy /Y ..\Source\ExcelDna.Integration\bin\Release\net452\ExcelDna.Integration.dll ..\Distribution\
 copy /Y ..\Source\ExcelDnaPack\bin\Release\net452\ExcelDnaPack.exe ..\Distribution\
 copy /Y ..\Source\ExcelDnaPack\bin\Release\net452\ExcelDnaPack.exe.config ..\Distribution\
-copy /Y ..\Source\ExcelDna.AddIn.Tasks\bin\Release\net472\ExcelDna.AddIn.Tasks.dll ..\Package\ExcelDna.AddIn\tools\
-copy /Y ..\Source\ExcelDna.AddIn.Tasks\bin\Release\net472\ExcelDna.AddIn.Tasks.pdb ..\Package\ExcelDna.AddIn\tools\
+if not exist "..\Source\ExcelDna.AddIn.Tasks\bin\Release\net472\" mkdir "..\Source\ExcelDna.AddIn.Tasks\bin\Release\net472\"
+copy /Y ..\Source\ExcelDna.AddIn.Tasks\bin\Release\net472\ExcelDna.AddIn.Tasks.dll ..\Package\ExcelDna.AddIn\tools\net472\
+copy /Y ..\Source\ExcelDna.AddIn.Tasks\bin\Release\net472\ExcelDna.AddIn.Tasks.pdb ..\Package\ExcelDna.AddIn\tools\net472\
+if not exist "..\Source\ExcelDna.AddIn.Tasks\bin\Release\net5.0-windows\" mkdir "..\Source\ExcelDna.AddIn.Tasks\bin\Release\net5.0-windows\"
+copy /Y ..\Source\ExcelDna.AddIn.Tasks\bin\Release\net5.0-windows\ExcelDna.AddIn.Tasks.dll ..\Package\ExcelDna.AddIn\tools\net5.0-windows\
+copy /Y ..\Source\ExcelDna.AddIn.Tasks\bin\Release\net5.0-windows\ExcelDna.AddIn.Tasks.pdb ..\Package\ExcelDna.AddIn\tools\net5.0-windows\
 pause

--- a/Package/ExcelDna.AddIn/ExcelDna.AddIn.nuspec
+++ b/Package/ExcelDna.AddIn/ExcelDna.AddIn.nuspec
@@ -10,13 +10,13 @@
         <repository type="git" url="https://github.com/Excel-DNA/ExcelDna" />
         <iconUrl>http://docs.excel-dna.net/NuGetIcon.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>Excel-DNA eases the development of Excel add-ins using .NET. 
+        <description>Excel-DNA eases the development of Excel add-ins using .NET.
     Add-ins created with Excel-DNA can export high-performance user-defined functions and macros, and can be packed into a single file for easy distribution and installation.
- 
+
     Excel versions 2007 through 2019 / Office 365 can be targeted with a single add-in.
     Advanced Excel features are supported, including multi-threaded recalculation, registration-free RTD servers and customized Ribbon and Task Pane interfaces and asynchronous functions.
 
-    Excel-DNA supports the .NET Framework version 4.5.2 and later (the version number used in the .dna file will be "4.0"). 
+    Excel-DNA supports the .NET Framework version 4.5.2 and later (the version number used in the .dna file will be "4.0").
 
     The Excel-Dna Runtime is free for all use, and distributed under a permissive open-source license that also allows commercial use.</description>
         <summary>Excel-DNA is an independent project to integrate .NET into Excel.</summary>
@@ -39,6 +39,8 @@
         <file src="tools\uninstall.ps1" target="tools\uninstall.ps1" />
         <file src="build\ExcelDna.AddIn.targets" target="build\ExcelDna.AddIn.targets" />
         <file src="tools\ExcelDna.AddIn.Tasks.dll" target="tools\ExcelDna.AddIn.Tasks.dll" />
+        <file src="tools\net472\ExcelDna.AddIn.Tasks.dll" target="tools\net472\ExcelDna.AddIn.Tasks.dll" />
+        <file src="tools\net5.0-windows\ExcelDna.AddIn.Tasks.dll" target="tools\net5.0-windows\ExcelDna.AddIn.Tasks.dll" />
         <file src="readme.txt" target="readme.txt" />
     </files>
 </package>

--- a/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
+++ b/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
@@ -4,9 +4,16 @@
     <ExcelDnaToolsPath Condition="$(ExcelDnaToolsPath) == '' Or $(ExcelDnaToolsPath) == '*Undefined*'">$(MSBuildThisFileDirectory)..\tools\</ExcelDnaToolsPath>
   </PropertyGroup>
 
-  <UsingTask TaskName="ExcelDna.AddIn.Tasks.SetDebuggerOptions" AssemblyFile="$(ExcelDnaToolsPath)ExcelDna.AddIn.Tasks.dll" />
-  <UsingTask TaskName="ExcelDna.AddIn.Tasks.CleanExcelAddIn" AssemblyFile="$(ExcelDnaToolsPath)ExcelDna.AddIn.Tasks.dll" />
-  <UsingTask TaskName="ExcelDna.AddIn.Tasks.CreateExcelAddIn" AssemblyFile="$(ExcelDnaToolsPath)ExcelDna.AddIn.Tasks.dll" />
+	<PropertyGroup Condition="'$(MSBuildRuntimeType)' == 'Core'">
+		<ExcelDnaTasksPath>$(ExcelDnaToolsPath)\net5.0-windows\</ExcelDnaTasksPath>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(MSBuildRuntimeType)' != 'Core'">
+		<ExcelDnaTasksPath>$(ExcelDnaToolsPath)\net472\</ExcelDnaTasksPath>
+	</PropertyGroup>
+
+  <UsingTask TaskName="ExcelDna.AddIn.Tasks.SetDebuggerOptions" AssemblyFile="$(ExcelDnaTasksPath)ExcelDna.AddIn.Tasks.dll" />
+  <UsingTask TaskName="ExcelDna.AddIn.Tasks.CleanExcelAddIn" AssemblyFile="$(ExcelDnaTasksPath)ExcelDna.AddIn.Tasks.dll" />
+  <UsingTask TaskName="ExcelDna.AddIn.Tasks.CreateExcelAddIn" AssemblyFile="$(ExcelDnaTasksPath)ExcelDna.AddIn.Tasks.dll" />
 
   <!--
     Extend the Clean target to call our ExcelDnaClean target

--- a/Source/ExcelDna.AddIn.Tasks/ExcelDna.AddIn.Tasks.csproj
+++ b/Source/ExcelDna.AddIn.Tasks/ExcelDna.AddIn.Tasks.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     
     <OutputType>Library</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net5.0-windows;net472</TargetFrameworks>
 
     <AssemblyTitle>Excel-DNA MSBuild Tasks</AssemblyTitle>
     <Description>MSBuild Tasks for Excel DNA</Description>
@@ -22,11 +22,15 @@
     <ProjectReference Include="..\ExcelDna.Integration\ExcelDna.Integration.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="EnvDTE" Version="8.0.2" />
   </ItemGroup>
-  
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0-windows' ">
+    <PackageReference Include="envdte" Version="16.9.31023.347" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.9.20" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.9.20" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="System.Management" />


### PR DESCRIPTION
### Summary
Projects that use ExcelDna.Addin can be built with dotnet core 5.0 on windows directly through ```dotnet build```, so thereby not requiring Visual Studio to be installed.

### Description
Multi-target Addin.Tasks for net472 and net5.0-windows.
Adds a new variable ExcelDnaTasksPath to the Excel.Addin.Targets to redirect to the correct Excel.Addin.Tasks.dll during build.

It's my first PR on ExcelDna - so consider this a draft PR...

