### PR TITLE
Optionally disable ExcelDnaPack compression

### DIFF
--- a/Package/ExcelDna.AddIn/content/ExcelDna.Build.props
+++ b/Package/ExcelDna.AddIn/content/ExcelDna.Build.props
@@ -72,6 +72,15 @@
       Suffix used for packed .xll files e.g. MyAddIn-packed.xll
     -->
     <ExcelDnaPackXllSuffix Condition="'$(ExcelDnaPackXllSuffix)' == ''">-packed</ExcelDnaPackXllSuffix>
+
+    <!--
+      Options used when packing .xll files.
+      When in trouble with your virus scanner, try uncommenting at least the resource compression properties.
+      The default is true for both compression and multithreaded runs when not specified.
+    -->
+    <!--<ExcelDnaPackCompressResources Condition="'$(ConfigurationName)' == 'Debug'">false</ExcelDnaPackCompressResources>-->
+    <!--<ExcelDnaPackRunMultithreaded  Condition="'$(ConfigurationName)' == 'Debug'">false</ExcelDnaPackRunMultithreaded>-->
+    <!--<ExcelDnaPackCompressResources Condition="'$(ConfigurationName)' == 'Release'">false</ExcelDnaPackCompressResources>-->
+    <!--<ExcelDnaPackRunMultithreaded  Condition="'$(ConfigurationName)' == 'Release'">false</ExcelDnaPackRunMultithreaded>-->
   </PropertyGroup>
 </Project>
-


### PR DESCRIPTION
My first pull request ever. Hope this goes well :-)

I've had some trouble with virus scanners since around october 2021. Read some stories about an increase of xlls spreading virusses as well, so they might have had to become more stringent.

I've had success disabling the compression feature of ExcelDnaPack. The scanner, in this case Thor Agent from Heimdal security, does not block my xll anymore.

This change makes the possibility of disabling compression more visible. Hope it helps somebody.