### PR TITLE
EnableDynamicLoading and other project settings

### DIFF
--- a/Package/ExcelDna.AddIn/ExcelDna.AddIn.nuspec
+++ b/Package/ExcelDna.AddIn/ExcelDna.AddIn.nuspec
@@ -48,6 +48,7 @@
         <file src="tools\install.ps1" target="tools\net452\install.ps1" />
         <file src="tools\uninstall.ps1" target="tools\net452\uninstall.ps1" />
         <file src="build\ExcelDna.AddIn.targets" target="build\ExcelDna.AddIn.targets" />
+        <file src="build\ExcelDna.AddIn.props" target="build\ExcelDna.AddIn.props" />
         <file src="tools\net452\ExcelDna.AddIn.Tasks.dll" target="tools\net452\ExcelDna.AddIn.Tasks.dll" />
         <file src="tools\net452\EnvDTE.dll" target="tools\net452\EnvDTE.dll" />
         <file src="tools\net452\Newtonsoft.Json.dll" target="tools\net452\Newtonsoft.Json.dll" />

--- a/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.props
+++ b/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.props
@@ -1,5 +1,6 @@
 <Project>
 	<PropertyGroup>
 		<EnableDynamicLoading>true</EnableDynamicLoading>
+		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
 	</PropertyGroup>
 </Project>

--- a/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.props
+++ b/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.props
@@ -1,0 +1,5 @@
+<Project>
+	<PropertyGroup>
+		<EnableDynamicLoading>true</EnableDynamicLoading>
+	</PropertyGroup>
+</Project>

--- a/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
+++ b/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
@@ -182,6 +182,8 @@
     <Error Text="ExcelDna32BitAddInSuffix and ExcelDna64BitAddInSuffix cannot be identical. Fix your ExcelDna.Build.props file"
               Condition="'$(ExcelDna32BitAddInSuffix)' == '$(ExcelDna64BitAddInSuffix)'" />
 
+	<Error Text="The target platform should be Windows. For example, &lt;TargetFramework&gt;net6.0-windows&lt;/TargetFramework&gt;." Condition="'$(TargetPlatformIdentifier)' != 'Windows'" />		
+
     <Warning Text="ExcelDnaCreate32BitAddIn and ExcelDnaCreate64BitAddIn are both 'false'. Nothing to do"
              Condition="('$(ExcelDnaCreate32BitAddIn)' == 'false') AND ('$(ExcelDnaCreate64BitAddIn)' == 'false')" />
 

--- a/Source/ExcelDna.AddIn.Tasks/ExcelDna.AddIn.Tasks.csproj
+++ b/Source/ExcelDna.AddIn.Tasks/ExcelDna.AddIn.Tasks.csproj
@@ -45,6 +45,10 @@
       <Link>ExcelDna.AddIn.targets</Link>
       <SubType>Designer</SubType>
     </None>
+    <None Include="..\..\Package\ExcelDna.AddIn\build\ExcelDna.AddIn.props">
+      <Link>ExcelDna.AddIn.props</Link>
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
 
   <Import Project="..\ExcelDna.PackedResources\ExcelDna.PackedResources.projitems" Label="Shared" />


### PR DESCRIPTION
When 'ExcelDna.AddIn' package is referenced:

* Set 'EnableDynamicLoading' to true if it is not set to false in the project file.

* Set 'ProduceReferenceAssembly' to false if it is not set to true in the project file.

* Give a build error if the target framework is 'net6.0' and not 'net6.0-windows' or some specific '-windows' version. 