### PR TITLE
Disabled spurious assembly load warnings in .NET 6

### DIFF
--- a/Source/ExcelDna.ManagedHost/AddInInitialize.cs
+++ b/Source/ExcelDna.ManagedHost/AddInInitialize.cs
@@ -16,7 +16,7 @@ namespace ExcelDna.ManagedHost
             //       before calling LoadIntegration, which will be the first time we try to resolve ExcelDna.Integration
             AssemblyManager.Initialize((IntPtr)hModuleXll, pathXll);
             // TODO: Load up the DnaFile and Assembly names ?
-            AppDomain.CurrentDomain.AssemblyResolve += (object sender, ResolveEventArgs args) => AssemblyManager.AssemblyResolve(new AssemblyName(args.Name));
+            AppDomain.CurrentDomain.AssemblyResolve += (object sender, ResolveEventArgs args) => AssemblyManager.AssemblyResolve(new AssemblyName(args.Name), true);
             return XlAddInInitialize((IntPtr)xlAddInExportInfoAddress, (IntPtr)hModuleXll, pathXll, AssemblyManager.GetResourceBytes, AssemblyManager.LoadFromAssemblyPath, AssemblyManager.LoadFromAssemblyBytes, Logger.SetIntegrationTraceSource);
         }
 
@@ -25,7 +25,7 @@ namespace ExcelDna.ManagedHost
             // NOTE: The sequence here is important - we install the AssemblyManage which can resolve packed assemblies
             //       before calling LoadIntegration, which will be the first time we try to resolve ExcelDna.Integration
             AssemblyManager.Initialize((IntPtr)hModuleXll, pathXll);
-            AppDomain.CurrentDomain.AssemblyResolve += (object sender, ResolveEventArgs args) => AssemblyManager.AssemblyResolve(new AssemblyName(args.Name));
+            AppDomain.CurrentDomain.AssemblyResolve += (object sender, ResolveEventArgs args) => AssemblyManager.AssemblyResolve(new AssemblyName(args.Name), true);
             return XlAddInInitialize((IntPtr)xlAddInExportInfoAddress, (IntPtr)hModuleXll, pathXll, AssemblyManager.GetResourceBytes, AssemblyManager.LoadFromAssemblyPath, AssemblyManager.LoadFromAssemblyBytes, Logger.SetIntegrationTraceSource);
         }
 #endif
@@ -54,13 +54,13 @@ namespace ExcelDna.ManagedHost
 #endif
 
 #if !NETCOREAPP
-    // NOTE: We need this code to be in a separate method, so that the assembly resolution for ExcelDna.Loader runs after the AssemblyManager is installed.
-    [MethodImpl(MethodImplOptions.NoInlining)]
+        // NOTE: We need this code to be in a separate method, so that the assembly resolution for ExcelDna.Loader runs after the AssemblyManager is installed.
+        [MethodImpl(MethodImplOptions.NoInlining)]
         static bool XlAddInInitialize(IntPtr xlAddInExportInfoAddress, IntPtr hModuleXll, string pathXll,
-            Func<string, int, byte[]> getResourceBytes,
-            Func<string, Assembly> loadFromAssemblyPath,
-            Func<byte[], byte[], Assembly> loadFromAssemblyBytes,
-            Action<TraceSource> setIntegrationTraceSource)
+                Func<string, int, byte[]> getResourceBytes,
+                Func<string, Assembly> loadFromAssemblyPath,
+                Func<byte[], byte[], Assembly> loadFromAssemblyBytes,
+                Action<TraceSource> setIntegrationTraceSource)
         {
             return XlAddIn.Initialize(xlAddInExportInfoAddress, hModuleXll, pathXll, getResourceBytes, loadFromAssemblyPath, loadFromAssemblyBytes, setIntegrationTraceSource);
         }

--- a/Source/ExcelDna.ManagedHost/AssemblyManager.cs
+++ b/Source/ExcelDna.ManagedHost/AssemblyManager.cs
@@ -39,7 +39,7 @@ namespace ExcelDna.ManagedHost
         }
 
         [MethodImpl(MethodImplOptions.Synchronized)]
-        internal static Assembly AssemblyResolve(AssemblyName assemblyName)
+        internal static Assembly AssemblyResolve(AssemblyName assemblyName, bool logMissingResources)
         {
             string name;
             byte[] assemblyBytes;
@@ -93,10 +93,13 @@ namespace ExcelDna.ManagedHost
             assemblyBytes = GetResourceBytes(name, 0);
             if (assemblyBytes == null)
             {
-                if (isResourceAssembly)
-                    Logger.Initialization.Verbose("Assembly {0} could not be loaded from resources (ResourceManager probing for satellite assemblies).", name);
-                else
-                    Logger.Initialization.Warn("Assembly {0} could not be loaded from resources.", name);
+                if (logMissingResources)
+                {
+                    if (isResourceAssembly)
+                        Logger.Initialization.Verbose("Assembly {0} could not be loaded from resources (ResourceManager probing for satellite assemblies).", name);
+                    else
+                        Logger.Initialization.Warn("Assembly {0} could not be loaded from resources.", name);
+                }
                 return null;
             }
 

--- a/Source/ExcelDna.ManagedHost/ExcelDnaAssemblyLoadContext.cs
+++ b/Source/ExcelDna.ManagedHost/ExcelDnaAssemblyLoadContext.cs
@@ -37,7 +37,7 @@ namespace ExcelDna.ManagedHost
             }
 
             // Finally we try the AssemblyManager
-            return AssemblyManager.AssemblyResolve(assemblyName);
+            return AssemblyManager.AssemblyResolve(assemblyName, false);
         }
 
         protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)


### PR DESCRIPTION
There are a lot of log entries like this when the code JIT-compiles:
 ExcelDna.Integration Warning: 1 : Assembly SYSTEM.DRAWING.COMMON could not be loaded from resources.

The AssemblyLoadContext.Load(AssemblyName) method provides the first chance for the AssemblyLoadContext to resolve, load, and return the assembly. Not loading an assembly from local resources is fine here and we should not log warnings.