### PR TITLE
Fixed a pack error on build

### DIFF
--- a/Source/ExcelDna.PackedResources/ExcelDnaPack.cs
+++ b/Source/ExcelDna.PackedResources/ExcelDnaPack.cs
@@ -88,7 +88,7 @@ namespace ExcelDna.PackedResources
             Console.WriteLine("Using base add-in " + xllInputPath);
 
             File.Copy(xllInputPath, xllOutputPath, false);
-            ResourceHelper.ResourceUpdater ru = new ResourceHelper.ResourceUpdater(xllOutputPath);
+            ResourceHelper.ResourceUpdater ru = new ResourceHelper.ResourceUpdater(Path.Combine(Directory.GetCurrentDirectory(), xllOutputPath));
             if (File.Exists(configPath))
             {
                 ru.AddFile(File.ReadAllBytes(configPath), "__MAIN__", ResourceHelper.TypeName.CONFIG, false, multithreading);  // Name here must exactly match name in ExcelDnaLoad.cpp.

--- a/Source/ExcelDna.PackedResources/ResourceHelper.cs
+++ b/Source/ExcelDna.PackedResources/ResourceHelper.cs
@@ -29,12 +29,12 @@ internal static class ResourceHelper
     private const ushort localeEnglishUS = 1033;
     private const ushort localeEnglishSA = 7177;
 
-    [DllImport("kernel32.dll")]
+    [DllImport("kernel32.dll", SetLastError = true)]
     private static extern IntPtr BeginUpdateResource(
         string pFileName,
         bool bDeleteExistingResources);
 
-    [DllImport("kernel32.dll")]
+    [DllImport("kernel32.dll", SetLastError = true)]
     private static extern bool EndUpdateResource(
         IntPtr hUpdate,
         bool fDiscard);

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget.sln
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget.sln
@@ -65,7 +65,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SDKDnaComServer", "SDKDnaCo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NET6DnaComServer", "NET6DnaComServer\NET6DnaComServer.csproj", "{47B73109-1742-46DE-A849-2E4B54443432}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NET6Sign", "NET6Sign\NET6Sign.csproj", "{6546D977-7245-4F1C-B983-8369E85218B0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NET6Sign", "NET6Sign\NET6Sign.csproj", "{6546D977-7245-4F1C-B983-8369E85218B0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FrameworksPack", "FrameworksPack\FrameworksPack.csproj", "{486B4265-C5C4-4686-908D-75CB7E9FDCF4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -197,6 +199,10 @@ Global
 		{6546D977-7245-4F1C-B983-8369E85218B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6546D977-7245-4F1C-B983-8369E85218B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6546D977-7245-4F1C-B983-8369E85218B0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{486B4265-C5C4-4686-908D-75CB7E9FDCF4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{486B4265-C5C4-4686-908D-75CB7E9FDCF4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{486B4265-C5C4-4686-908D-75CB7E9FDCF4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{486B4265-C5C4-4686-908D-75CB7E9FDCF4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/FrameworksPack/AddIn.cs
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/FrameworksPack/AddIn.cs
@@ -1,0 +1,21 @@
+﻿using System.IO;
+using System.Windows.Forms;
+using ExcelDna.Integration;
+
+namespace FrameworksPack
+{
+    public class AddIn : IExcelAddIn
+    {
+        public void AutoOpen()
+        {
+            var thisAddInName = Path.GetFileName((string)XlCall.Excel(XlCall.xlGetName));
+            var message = string.Format("Excel-DNA Add-In '{0}' loaded!", thisAddInName);
+
+            MessageBox.Show(message, thisAddInName, MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+
+        public void AutoClose()
+        {
+        }
+    }
+}

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/FrameworksPack/FrameworksPack.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/FrameworksPack/FrameworksPack.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;net6.0-windows</TargetFrameworks>
+    <UseWindowsForms>True</UseWindowsForms>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0-windows' ">
+    <Reference Include="ExcelDna.Integration">
+      <HintPath>..\..\.exceldna.addin\tools\net6.0-windows\ExcelDna.Integration.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+    <Reference Include="ExcelDna.Integration">
+      <HintPath>..\..\.exceldna.addin\tools\net452\ExcelDna.Integration.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+  <Import Project="$(ProjectDir)..\..\.exceldna.addin\build\ExcelDna.AddIn.targets" />
+
+</Project>


### PR DESCRIPTION
> `<TargetFrameworks>net472;net6.0-windows</TargetFrameworks>`
> 
> First TFM builds OK, then second one fails:
> 
> 1>  Target ExcelDnaPack:
> 1>    ExcelDnaPack: bin\Debug\net6.0-windows\TestNuNuGet-AddIn.dna -> bin\Debug\net6.0-windows\TestNuNuGet-AddIn-packed.xll
> 1>    PackExcelAddIn: Running PackExcelAddIn Task
> 1>    MSBUILD : PackExcelAddIn error DNA126955310: The operation completed successfully
> 1>    MSBUILD : PackExcelAddIn error DNA126955310: System.ComponentModel.Win32Exception (0x80004005): The operation completed successfully
> 1>    MSBUILD : PackExcelAddIn error DNA126955310:    at ResourceHelper.ResourceUpdater..ctor(String fileName)
> 1>    MSBUILD : PackExcelAddIn error DNA126955310:    at ExcelDna.PackedResources.ExcelDnaPack.Pack(String dnaPath, String xllOutputPathParam, Boolean compress, Boolean multithreading, Boolean overwrite, String usageInfo)
> 1>    MSBUILD : PackExcelAddIn error DNA126955310:    at ExcelDna.AddIn.Tasks.PackExcelAddIn.Execute()

I don't know why an absolute path is needed in this case, but it fixed the problem for me. 