### PR TITLE
Fixed Error copying version to output version

### DIFF
--- a/Source/ExcelDna.AddIn.Tasks/Properties/ExcelDna.AddIn.Tasks.targets
+++ b/Source/ExcelDna.AddIn.Tasks/Properties/ExcelDna.AddIn.Tasks.targets
@@ -68,5 +68,10 @@
 		OverwriteReadOnlyFiles="true"
 		SkipUnchangedFiles="true" />
 
+	<ItemGroup>
+		<ExcelDnaTestFilesToMove Include="$(ExcelDnaTestPackageDir)tools\net6.0-windows\*.*" />
+	</ItemGroup>
+	<Move SourceFiles="@(ExcelDnaTestFilesToMove)" DestinationFolder="$(ExcelDnaTestPackageDir)tools\net6.0-windows7.0" />
+
 	</Target>
 </Project>

--- a/Source/ExcelDna.PackedResources/ExcelDnaPack.cs
+++ b/Source/ExcelDna.PackedResources/ExcelDnaPack.cs
@@ -188,7 +188,7 @@ namespace ExcelDna.PackedResources
                         }
                         try
                         {
-                            ru.CopyFileVersion(path);
+                            ru.CopyFileVersion(Path.Combine(Directory.GetCurrentDirectory(), path));
                             copiedVersion = true;
                         }
                         catch (Exception e)

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget.sln
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget.sln
@@ -69,6 +69,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NET6Sign", "NET6Sign\NET6Si
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FrameworksPack", "FrameworksPack\FrameworksPack.csproj", "{486B4265-C5C4-4686-908D-75CB7E9FDCF4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FrameworksUseVersionAsOutputVersion", "FrameworksUseVersionAsOutputVersion\FrameworksUseVersionAsOutputVersion.csproj", "{35BE64BA-0143-47E3-BCD6-E08F5C7996B6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -203,6 +205,10 @@ Global
 		{486B4265-C5C4-4686-908D-75CB7E9FDCF4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{486B4265-C5C4-4686-908D-75CB7E9FDCF4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{486B4265-C5C4-4686-908D-75CB7E9FDCF4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{35BE64BA-0143-47E3-BCD6-E08F5C7996B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{35BE64BA-0143-47E3-BCD6-E08F5C7996B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35BE64BA-0143-47E3-BCD6-E08F5C7996B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{35BE64BA-0143-47E3-BCD6-E08F5C7996B6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/FrameworksUseVersionAsOutputVersion/AddIn.cs
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/FrameworksUseVersionAsOutputVersion/AddIn.cs
@@ -1,0 +1,21 @@
+﻿using System.IO;
+using System.Windows.Forms;
+using ExcelDna.Integration;
+
+namespace FrameworksUseVersionAsOutputVersion
+{
+    public class AddIn : IExcelAddIn
+    {
+        public void AutoOpen()
+        {
+            var thisAddInName = Path.GetFileName((string)XlCall.Excel(XlCall.xlGetName));
+            var message = string.Format("Excel-DNA Add-In '{0}' loaded!", thisAddInName);
+
+            MessageBox.Show(message, thisAddInName, MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+
+        public void AutoClose()
+        {
+        }
+    }
+}

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/FrameworksUseVersionAsOutputVersion/FrameworksUseVersionAsOutputVersion-AddIn.dna
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/FrameworksUseVersionAsOutputVersion/FrameworksUseVersionAsOutputVersion-AddIn.dna
@@ -1,0 +1,3 @@
+<DnaLibrary Name="FrameworksUseVersionAsOutputVersion" RuntimeVersion="v4.0">
+  <ExternalLibrary Path="FrameworksUseVersionAsOutputVersion.dll" Pack="true" UseVersionAsOutputVersion="true" />
+</DnaLibrary>

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/FrameworksUseVersionAsOutputVersion/FrameworksUseVersionAsOutputVersion.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/FrameworksUseVersionAsOutputVersion/FrameworksUseVersionAsOutputVersion.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net472;net6.0-windows</TargetFrameworks>

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/FrameworksUseVersionAsOutputVersion/FrameworksUseVersionAsOutputVersion.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/FrameworksUseVersionAsOutputVersion/FrameworksUseVersionAsOutputVersion.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFrameworks>net472;net6.0-windows</TargetFrameworks>
     <UseWindowsForms>True</UseWindowsForms>
+
+    <FileVersion>1.2.3</FileVersion>
+    <InformationalVersion>1.2.3</InformationalVersion>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0-windows' ">

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/NET6DisableAssemblyContextUnload/NET6DisableAssemblyContextUnload.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/NET6DisableAssemblyContextUnload/NET6DisableAssemblyContextUnload.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <Reference Include="ExcelDna.Integration">
-      <HintPath>..\..\.exceldna.addin\tools\net6.0-windows\ExcelDna.Integration.dll</HintPath>
+      <HintPath>..\..\.exceldna.addin\tools\net6.0-windows7.0\ExcelDna.Integration.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/NET6LaunchSettings/NET6LaunchSettings.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/NET6LaunchSettings/NET6LaunchSettings.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <Reference Include="ExcelDna.Integration">
-      <HintPath>..\..\.exceldna.addin\tools\net6.0-windows\ExcelDna.Integration.dll</HintPath>
+      <HintPath>..\..\.exceldna.addin\tools\net6.0-windows7.0\ExcelDna.Integration.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/NET6LaunchSettingsDisabled/NET6LaunchSettingsDisabled.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/NET6LaunchSettingsDisabled/NET6LaunchSettingsDisabled.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <Reference Include="ExcelDna.Integration">
-      <HintPath>..\..\.exceldna.addin\tools\net6.0-windows\ExcelDna.Integration.dll</HintPath>
+      <HintPath>..\..\.exceldna.addin\tools\net6.0-windows7.0\ExcelDna.Integration.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/NET6LaunchSettingsVB/NET6LaunchSettingsVB.vbproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/NET6LaunchSettingsVB/NET6LaunchSettingsVB.vbproj
@@ -12,7 +12,7 @@
     
     <ItemGroup>
         <Reference Include="ExcelDna.Integration">
-            <HintPath>..\..\.exceldna.addin\tools\net6.0-windows\ExcelDna.Integration.dll</HintPath>
+            <HintPath>..\..\.exceldna.addin\tools\net6.0-windows7.0\ExcelDna.Integration.dll</HintPath>
         </Reference>
     </ItemGroup>
 

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/NET6Minimal/NET6Minimal.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/NET6Minimal/NET6Minimal.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <Reference Include="ExcelDna.Integration">
-      <HintPath>..\..\.exceldna.addin\tools\net6.0-windows\ExcelDna.Integration.dll</HintPath>
+      <HintPath>..\..\.exceldna.addin\tools\net6.0-windows7.0\ExcelDna.Integration.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/NET6Sign/NET6Sign.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/NET6Sign/NET6Sign.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <Reference Include="ExcelDna.Integration">
-      <HintPath>..\..\.exceldna.addin\tools\net6.0-windows\ExcelDna.Integration.dll</HintPath>
+      <HintPath>..\..\.exceldna.addin\tools\net6.0-windows7.0\ExcelDna.Integration.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/NET6Unpack/NET6Unpack.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/NET6Unpack/NET6Unpack.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <Reference Include="ExcelDna.Integration">
-      <HintPath>..\..\.exceldna.addin\tools\net6.0-windows\ExcelDna.Integration.dll</HintPath>
+      <HintPath>..\..\.exceldna.addin\tools\net6.0-windows7.0\ExcelDna.Integration.dll</HintPath>
     </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
When targeting multiple frameworks and using UseVersionAsOutputVersion="true":

> 1>MSBUILD : PackExcelAddIn error DNA731704007:   ~~> ERROR: Error copying version to output version: The system cannot find the file specified
> 1>MSBUILD : PackExcelAddIn error DNA731704007: System.InvalidOperationException:   ~~> ERROR: Error copying version to output version: The system cannot find the file specified
> 1>MSBUILD : PackExcelAddIn error DNA731704007:    at ExcelDna.PackedResources.ExcelDnaPack.PackDnaLibrary(Byte[] dnaContent, String dnaDirectory, ResourceUpdater ru, Boolean compress, Boolean multithreading) in e:\programming\Govert\ExcelDna\Source\ExcelDna.PackedResources\ExcelDnaPack.cs:line 197
> 1>MSBUILD : PackExcelAddIn error DNA731704007:    at ExcelDna.PackedResources.ExcelDnaPack.Pack(String dnaPath, String xllOutputPathParam, Boolean compress, Boolean multithreading, Boolean overwrite, String usageInfo) in e:\programming\Govert\ExcelDna\Source\ExcelDna.PackedResources\ExcelDnaPack.cs:line 97
> 1>MSBUILD : PackExcelAddIn error DNA731704007:    at ExcelDna.AddIn.Tasks.PackExcelAddIn.Execute() in e:\programming\Govert\ExcelDna\Source\ExcelDna.AddIn.Tasks\PackExcelAddIn.cs:line 31
> 1>Done building project "FrameworksUseVersionAsOutputVersion.csproj" -- FAILED.