### PR TITLE
LogPackDna#518

### DIFF
--- a/Source/ExcelDna.AddIn.Tasks/CleanExcelAddIn.cs
+++ b/Source/ExcelDna.AddIn.Tasks/CleanExcelAddIn.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using ExcelDna.AddIn.Tasks.Logging;
 using ExcelDna.AddIn.Tasks.Utils;
+using ExcelDna.PackedResources.Logging;
 
 namespace ExcelDna.AddIn.Tasks
 {

--- a/Source/ExcelDna.AddIn.Tasks/CreateExcelAddIn.cs
+++ b/Source/ExcelDna.AddIn.Tasks/CreateExcelAddIn.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using ExcelDna.AddIn.Tasks.Logging;
 using ExcelDna.AddIn.Tasks.Utils;
+using ExcelDna.PackedResources.Logging;
 
 namespace ExcelDna.AddIn.Tasks
 {
@@ -360,7 +361,7 @@ namespace ExcelDna.AddIn.Tasks
                 return;
 
             List<string> filesToPublish = new List<string>();
-            int result = PackedResources.ExcelDnaPack.Pack(dnaPath, null, false, false, false, null, filesToPublish, false);
+            int result = PackedResources.ExcelDnaPack.Pack(dnaPath, null, false, false, false, null, filesToPublish, false, _log);
             if (result != 0)
                 throw new ApplicationException($"Pack failed with exit code {result}.");
             foreach (string file in filesToPublish)

--- a/Source/ExcelDna.AddIn.Tasks/ExcelDebugTask.cs
+++ b/Source/ExcelDna.AddIn.Tasks/ExcelDebugTask.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using ExcelDna.AddIn.Tasks.Logging;
+using ExcelDna.PackedResources.Logging;
 using Microsoft.Build.Framework;
 using ExcelDna.AddIn.Tasks.Utils;
 

--- a/Source/ExcelDna.AddIn.Tasks/PackExcelAddIn.cs
+++ b/Source/ExcelDna.AddIn.Tasks/PackExcelAddIn.cs
@@ -2,6 +2,7 @@
 using Microsoft.Build.Framework;
 using ExcelDna.AddIn.Tasks.Logging;
 using ExcelDna.AddIn.Tasks.Utils;
+using ExcelDna.PackedResources.Logging;
 using System.IO;
 
 namespace ExcelDna.AddIn.Tasks
@@ -34,7 +35,7 @@ namespace ExcelDna.AddIn.Tasks
                 useManagedResourceResolver = PackManagedOnWindows || !OperatingSystem.IsWindows();
 #endif
 
-                int result = ExcelDna.PackedResources.ExcelDnaPack.Pack(OutputDnaFileName, OutputPackedXllFileName, CompressResources, RunMultithreaded, true, null, null, useManagedResourceResolver);
+                int result = ExcelDna.PackedResources.ExcelDnaPack.Pack(OutputDnaFileName, OutputPackedXllFileName, CompressResources, RunMultithreaded, true, null, null, useManagedResourceResolver, _log);
                 if (result != 0)
                     throw new ApplicationException($"Pack failed with exit code {result}.");
 

--- a/Source/ExcelDna.AddIn.Tasks/SetDebuggerOptions.cs
+++ b/Source/ExcelDna.AddIn.Tasks/SetDebuggerOptions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using ExcelDna.AddIn.Tasks.Logging;
 using Microsoft.Build.Framework;
 using ExcelDna.AddIn.Tasks.Utils;
+using ExcelDna.PackedResources.Logging;
 
 namespace ExcelDna.AddIn.Tasks
 {

--- a/Source/ExcelDna.AddIn.Tasks/Utils/DevToolsEnvironment.cs
+++ b/Source/ExcelDna.AddIn.Tasks/Utils/DevToolsEnvironment.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Text.RegularExpressions;
-using ExcelDna.AddIn.Tasks.Logging;
+using ExcelDna.PackedResources.Logging;
 using Process = System.Diagnostics.Process;
 
 namespace ExcelDna.AddIn.Tasks.Utils

--- a/Source/ExcelDna.AddIn.Tasks/Utils/ExcelDetector.cs
+++ b/Source/ExcelDna.AddIn.Tasks/Utils/ExcelDetector.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Security.AccessControl;
 using Microsoft.Win32;
-using ExcelDna.AddIn.Tasks.Logging;
+using ExcelDna.PackedResources.Logging;
 
 namespace ExcelDna.AddIn.Tasks.Utils
 {

--- a/Source/ExcelDna.AddIn.Tasks/Utils/ExcelDnaProject.cs
+++ b/Source/ExcelDna.AddIn.Tasks/Utils/ExcelDnaProject.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.IO;
-using ExcelDna.AddIn.Tasks.Logging;
+using ExcelDna.PackedResources.Logging;
 
 namespace ExcelDna.AddIn.Tasks.Utils
 {

--- a/Source/ExcelDna.AddIn.Tasks/Utils/ProcessRunner.cs
+++ b/Source/ExcelDna.AddIn.Tasks/Utils/ProcessRunner.cs
@@ -1,6 +1,6 @@
-﻿using ExcelDna.AddIn.Tasks.Logging;
-using System;
+﻿using System;
 using System.Diagnostics;
+using ExcelDna.PackedResources.Logging;
 
 namespace ExcelDna.AddIn.Tasks.Utils
 {

--- a/Source/ExcelDna.AddIn.Tasks/Utils/SignTool.cs
+++ b/Source/ExcelDna.AddIn.Tasks/Utils/SignTool.cs
@@ -1,6 +1,6 @@
-﻿using ExcelDna.AddIn.Tasks.Logging;
-using System;
+﻿using System;
 using System.Diagnostics;
+using ExcelDna.PackedResources.Logging;
 
 namespace ExcelDna.AddIn.Tasks.Utils
 {

--- a/Source/ExcelDna.PackedResources/ExcelDna.PackedResources.projitems
+++ b/Source/ExcelDna.PackedResources/ExcelDna.PackedResources.projitems
@@ -10,6 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)IResourceResolver.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Logging\MessageImportance.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Logging\IBuildLogger.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lzma\CRC.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lzma\ICoder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lzma\IMatchFinder.cs" />

--- a/Source/ExcelDna.PackedResources/ExcelDnaPack.cs
+++ b/Source/ExcelDna.PackedResources/ExcelDnaPack.cs
@@ -2,13 +2,14 @@
 using System.Collections.Generic;
 using System.IO;
 using ExcelDna.Integration;
+using ExcelDna.PackedResources.Logging;
 using System.Reflection;
 
 namespace ExcelDna.PackedResources
 {
     internal class ExcelDnaPack
     {
-        public static int Pack(string dnaPath, string xllOutputPathParam, bool compress, bool multithreading, bool overwrite, string usageInfo, List<string> filesToPublish, bool useManagedResourceResolver)
+        public static int Pack(string dnaPath, string xllOutputPathParam, bool compress, bool multithreading, bool overwrite, string usageInfo, List<string> filesToPublish, bool useManagedResourceResolver, IBuildLogger buildLogger)
         {
             string dnaDirectory = Path.GetDirectoryName(dnaPath);
             string dnaFilePrefix = Path.GetFileNameWithoutExtension(dnaPath);
@@ -20,7 +21,7 @@ namespace ExcelDna.PackedResources
 
             if (!File.Exists(dnaPath))
             {
-                Console.Error.Write("ERROR: Add-in .dna file " + dnaPath + " not found.\r\n\r\n" + usageInfo);
+                buildLogger.Error(typeof(ExcelDnaPack), "ERROR: Add-in .dna file {0} not found.\r\n\r\n{1}", dnaPath, usageInfo);
                 return 1;
             }
 
@@ -43,7 +44,7 @@ namespace ExcelDna.PackedResources
                 }
                 catch
                 {
-                    Console.Error.Write("ERROR: Existing output .xll file " + xllOutputPath + "could not be deleted. (Perhaps loaded in Excel?)\r\n\r\nExiting ExcelDnaPack.");
+                    buildLogger.Error(typeof(ExcelDnaPack), "ERROR: Existing output .xll file {0} could not be deleted. (Perhaps loaded in Excel?)\r\n\r\nExiting ExcelDnaPack.", xllOutputPath);
                     return 1;
                 }
             }
@@ -62,7 +63,7 @@ namespace ExcelDna.PackedResources
                 }
                 catch (Exception ex)
                 {
-                    Console.Error.Write("ERROR: Output directory " + outputDirectory + "could not be created. Error: " + ex.Message + "\r\n\r\nExiting ExcelDnaPack.");
+                    buildLogger.Error(typeof(ExcelDnaPack), "ERROR: Output directory {0} could not be created. Error: {1}\r\n\r\nExiting ExcelDnaPack.", outputDirectory, ex.Message);
                     return 1;
                 }
             }
@@ -80,15 +81,15 @@ namespace ExcelDna.PackedResources
                     xllInputPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ExcelDna.xll");
                     if (!File.Exists(xllInputPath))
                     {
-                        Console.Error.WriteLine("ERROR: Base add-in not found.\r\n\r\n" + usageInfo);
+                        buildLogger.Error(typeof(ExcelDnaPack), "ERROR: Base add-in not found.\r\n\r\n {0}", usageInfo);
                         return 1;
                     }
                 }
             }
-            Console.WriteLine("Using base add-in " + xllInputPath);
+            buildLogger.Information("Using base add-in " + xllInputPath);
 
             if (useManagedResourceResolver)
-                Console.WriteLine("Using managed resource packing.");
+                buildLogger.Information("Using managed resource packing.");
 
             ResourceHelper.ResourceUpdater ru = null;
             if (filesToPublish == null)
@@ -108,7 +109,7 @@ namespace ExcelDna.PackedResources
                     filesToPublish.Add(configPath);
             }
             byte[] dnaBytes = File.ReadAllBytes(dnaPath);
-            byte[] dnaContentForPacking = PackDnaLibrary(dnaBytes, dnaDirectory, ru, compress, multithreading, filesToPublish);
+            byte[] dnaContentForPacking = PackDnaLibrary(dnaBytes, dnaDirectory, ru, compress, multithreading, filesToPublish, buildLogger);
             if (filesToPublish == null)
             {
                 ru.AddFile(dnaContentForPacking, "__MAIN__", ResourceHelper.TypeName.DNA, false, multithreading); // Name here must exactly match name in DnaLibrary.Initialize.
@@ -118,13 +119,13 @@ namespace ExcelDna.PackedResources
             {
                 filesToPublish.Add(dnaPath);
             }
-            Console.WriteLine("Completed Packing {0}.", xllOutputPath);
+            buildLogger.Information("Completed Packing {0}.", xllOutputPath);
 
             // All OK - set process exit code to 'Success'
             return 0;
         }
 
-        static private byte[] PackDnaLibrary(byte[] dnaContent, string dnaDirectory, ResourceHelper.ResourceUpdater ru, bool compress, bool multithreading, List<string> filesToPublish)
+        static private byte[] PackDnaLibrary(byte[] dnaContent, string dnaDirectory, ResourceHelper.ResourceUpdater ru, bool compress, bool multithreading, List<string> filesToPublish, IBuildLogger buildLogger)
         {
             string errorMessage;
             DnaLibrary dna = DnaLibrary.LoadFrom(dnaContent, dnaDirectory);
@@ -132,6 +133,7 @@ namespace ExcelDna.PackedResources
             {
                 // TODO: Better error handling here.
                 errorMessage = "ERROR: .dna file could not be loaded. Possibly malformed xml content? ABORTING.";
+                buildLogger.Error(typeof(ExcelDnaPack), errorMessage);
                 throw new InvalidOperationException(errorMessage);
             }
             if (dna.ExternalLibraries != null)
@@ -142,17 +144,19 @@ namespace ExcelDna.PackedResources
                     var path = dna.ResolvePath(ext.Path);
                     if (!File.Exists(path))
                     {
-                        errorMessage = string.Format("!!! ERROR: ExternalLibrary `{0}` not found. ABORTING.", ext.Path);
+                        var format = "!!! ERROR: ExternalLibrary `{0}` not found. ABORTING.";
+                        errorMessage = string.Format(format, ext.Path);
+                        buildLogger.Error(typeof(ExcelDnaPack), format, ext.Path);
                         throw new InvalidOperationException(errorMessage);
                     }
 
                     if (ext.Pack)
                     {
-                        Console.WriteLine("  ~~> ExternalLibrary path {0} resolved to {1}.", ext.Path, path);
+                        buildLogger.Information("  ~~> ExternalLibrary path {0} resolved to {1}.", ext.Path, path);
                         if (Path.GetExtension(path).Equals(".DNA", StringComparison.OrdinalIgnoreCase))
                         {
                             string name = Path.GetFileNameWithoutExtension(path).ToUpperInvariant() + "_" + lastPackIndex++ + ".DNA";
-                            byte[] dnaContentForPacking = PackDnaLibrary(File.ReadAllBytes(path), Path.GetDirectoryName(path), ru, compress, multithreading, filesToPublish);
+                            byte[] dnaContentForPacking = PackDnaLibrary(File.ReadAllBytes(path), Path.GetDirectoryName(path), ru, compress, multithreading, filesToPublish, buildLogger);
                             if (filesToPublish == null)
                             {
                                 ru.AddFile(dnaContentForPacking, name, ResourceHelper.TypeName.DNA, compress, multithreading);
@@ -192,7 +196,9 @@ namespace ExcelDna.PackedResources
                                     resolvedTypeLibPath = DnaLibrary.ResolvePath(ext.TypeLibPath, System.IO.Path.GetDirectoryName(path)); // null is unresolved
                                     if (resolvedTypeLibPath == null)
                                     {
-                                        errorMessage = string.Format("!!! ERROR: ExternalLibrary TypeLib path {0} could not be resolved.", ext.TypeLibPath);
+                                        var format = "!!! ERROR: ExternalLibrary TypeLib path {0} could not be resolved.";
+                                        errorMessage = string.Format(format, ext.TypeLibPath);
+                                        buildLogger.Error(typeof(ExcelDnaPack), format, ext.TypeLibPath);
                                         throw new InvalidOperationException(errorMessage);
                                     }
                                 }
@@ -210,7 +216,7 @@ namespace ExcelDna.PackedResources
                             {
                                 if (filesToPublish == null)
                                 {
-                                    Console.WriteLine("  ~~> ExternalLibrary typelib path {0} resolved to {1}.", ext.TypeLibPath, resolvedTypeLibPath);
+                                    buildLogger.Information("  ~~> ExternalLibrary typelib path {0} resolved to {1}.", ext.TypeLibPath, resolvedTypeLibPath);
                                     int packedIndex = ru.AddTypeLib(File.ReadAllBytes(resolvedTypeLibPath));
                                     ext.TypeLibPath = "packed:" + packedIndex.ToString();
                                 }
@@ -225,7 +231,7 @@ namespace ExcelDna.PackedResources
                     {
                         if (copiedVersion)
                         {
-                            Console.WriteLine("  ~~> Assembly version already copied from previous ExternalLibrary; ignoring 'UseVersionAsOutputVersion' attribute.");
+                            buildLogger.Information("  ~~> Assembly version already copied from previous ExternalLibrary; ignoring 'UseVersionAsOutputVersion' attribute.");
                             continue;
                         }
                         try
@@ -235,7 +241,9 @@ namespace ExcelDna.PackedResources
                         }
                         catch (Exception e)
                         {
-                            errorMessage = string.Format("  ~~> ERROR: Error copying version to output version: {0}", e.Message);
+                            var format = "  ~~> ERROR: Error copying version to output version: {0}";
+                            errorMessage = string.Format(format, e.Message);
+                            buildLogger.Error(typeof(ExcelDnaPack), format, e.Message);
                             throw new InvalidOperationException(errorMessage);
                         }
                     }
@@ -288,7 +296,7 @@ namespace ExcelDna.PackedResources
                         }
 
                         path = dna.ResolvePath(rf.Path);
-                        Console.WriteLine("  ~~> Assembly path {0} resolved to {1}.", rf.Path, path);
+                        buildLogger.Information("  ~~> Assembly path {0} resolved to {1}.", rf.Path, path);
                     }
                     if (path == null && rf.Name != null)
                     {
@@ -301,17 +309,19 @@ namespace ExcelDna.PackedResources
                             if (ass != null)
                             {
                                 path = ass.Location;
-                                Console.WriteLine("  ~~> Assembly {0} 'Load'ed from location {1}.", rf.Name, path);
+                                buildLogger.Information("  ~~> Assembly {0} 'Load'ed from location {1}.", rf.Name, path);
                             }
                         }
                         catch (Exception e)
                         {
-                            Console.WriteLine("  ~~> Assembly {0} not 'Load'ed. Exception: {1}", rf.Name, e);
+                            buildLogger.Error(e, "  ~~> Assembly {0} not 'Load'ed. Exception: {1}", rf.Name, e);
                         }
                     }
                     if (path == null)
                     {
-                        errorMessage = string.Format("  ~~> ERROR: Reference with Path: {0} and Name: {1} NOT FOUND.", rf.Path, rf.Name);
+                        var format = "  ~~> ERROR: Reference with Path: {0} and Name: {1} NOT FOUND.";
+                        errorMessage = string.Format(format, rf.Path, rf.Name);
+                        buildLogger.Error(typeof(ExcelDnaPack), format, rf.Path, rf.Name);
                         throw new InvalidOperationException(errorMessage);
                     }
 
@@ -337,7 +347,9 @@ namespace ExcelDna.PackedResources
                     string path = dna.ResolvePath(image.Path);
                     if (path == null)
                     {
-                        errorMessage = string.Format("  ~~> ERROR: Image path {0} NOT RESOLVED.", image.Path);
+                        var format = "  ~~> ERROR: Image path {0} NOT RESOLVED.";
+                        errorMessage = string.Format(format, image.Path);
+                        buildLogger.Error(typeof(ExcelDnaPack), format, image.Path);
                         throw new InvalidOperationException(errorMessage);
                     }
                     if (filesToPublish == null)
@@ -362,7 +374,9 @@ namespace ExcelDna.PackedResources
                         string path = dna.ResolvePath(source.Path);
                         if (path == null)
                         {
-                            errorMessage = string.Format("  ~~> ERROR: Source path {0} NOT RESOLVED.", source.Path);
+                            var format = "  ~~> ERROR: Source path {0} NOT RESOLVED.";
+                            errorMessage = string.Format(format, source.Path);
+                            buildLogger.Error(typeof(ExcelDnaPack), format, source.Path);
                             throw new InvalidOperationException(errorMessage);
                         }
                         if (filesToPublish == null)
@@ -379,6 +393,7 @@ namespace ExcelDna.PackedResources
                     }
                 }
             }
+
             return DnaLibrary.Save(dna);
         }
 

--- a/Source/ExcelDna.PackedResources/Logging/IBuildLogger.cs
+++ b/Source/ExcelDna.PackedResources/Logging/IBuildLogger.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using Microsoft.Build.Framework;
 
-namespace ExcelDna.AddIn.Tasks.Logging
+namespace ExcelDna.PackedResources.Logging
 {
     public interface IBuildLogger
     {
-        void Message(MessageImportance importance, string format, params object[] args);
+        void Message(LogImportance importance, string format, params object[] args);
         void Verbose(string format, params object[] args);
         void Debug(string format, params object[] args);
         void Information(string format, params object[] args);
@@ -14,6 +13,7 @@ namespace ExcelDna.AddIn.Tasks.Logging
         void Warning(string code, string format, params object[] args);
 
         void Error(Exception exception, string format, params object[] args);
+        void Error(Type errorSource, string format, params object[] args);
         void Error(string code, string format, params object[] args);
     }
 }

--- a/Source/ExcelDna.PackedResources/Logging/MessageImportance.cs
+++ b/Source/ExcelDna.PackedResources/Logging/MessageImportance.cs
@@ -1,0 +1,9 @@
+﻿namespace ExcelDna.PackedResources.Logging
+{
+    public enum LogImportance
+    {
+        High,
+        Normal,
+        Low
+    }
+}

--- a/Source/ExcelDnaPack/ConsoleLogger.cs
+++ b/Source/ExcelDnaPack/ConsoleLogger.cs
@@ -1,29 +1,26 @@
 ﻿using System;
-using Microsoft.Build.Framework;
 using ExcelDna.PackedResources.Logging;
 
 namespace ExcelDna.AddIn.Tasks.Logging
 {
-    internal class BuildLogger : IBuildLogger
+    internal class ConsoleLogger : IBuildLogger
     {
-        private readonly ITask _buildTask;
         private readonly string _targetName;
 
-        public BuildLogger(ITask buildTask, string targetName)
+        public ConsoleLogger(string targetName)
         {
             if (string.IsNullOrWhiteSpace(targetName))
             {
                 throw new ArgumentException("Value cannot be null or whitespace.", nameof(targetName));
             }
 
-            _buildTask = buildTask ?? throw new ArgumentNullException(nameof(buildTask));
             _targetName = targetName;
         }
 
         public void Message(LogImportance importance, string format, params object[] args)
         {
-            _buildTask.BuildEngine.LogMessageEvent(new BuildMessageEventArgs($"{_targetName}: {string.Format(format, args)}",
-                _targetName, _targetName, (MessageImportance)importance));
+            Console.WriteLine($"{_targetName}: {string.Format(format, args)}",
+                _targetName, _targetName, importance);
         }
 
         public void Verbose(string format, params object[] args)
@@ -50,8 +47,7 @@ namespace ExcelDna.AddIn.Tasks.Logging
 
         public void Warning(string code, string format, params object[] args)
         {
-            _buildTask.BuildEngine.LogWarningEvent(new BuildWarningEventArgs(_targetName, code, null, 0, 0, 0, 0,
-                string.Format(format, args), _targetName, _targetName));
+            Message(LogImportance.Normal, $"{code}:{format}", args);
         }
 
         public void Error(Exception exception, string format, params object[] args)
@@ -68,8 +64,7 @@ namespace ExcelDna.AddIn.Tasks.Logging
 
         public void Error(string code, string format, params object[] args)
         {
-            _buildTask.BuildEngine.LogErrorEvent(new BuildErrorEventArgs(_targetName, code, null, 0, 0, 0, 0,
-                string.Format(format, args), _targetName, _targetName));
+            Message(LogImportance.High, $"{code}:{format}", args);
         }
 
         private static string GetErrorCode(Exception exception)

--- a/Source/ExcelDnaPack/PackProgram.cs
+++ b/Source/ExcelDnaPack/PackProgram.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 
 using System.IO;
 using ExcelDna.Integration;
+using ExcelDna.AddIn.Tasks.Logging;
 
 namespace ExcelDnaPack
 {
@@ -124,7 +125,7 @@ Other assemblies are packed if marked with Pack=""true"" in the .dna file.
                 }
             }
 
-            int result = ExcelDna.PackedResources.ExcelDnaPack.Pack(dnaPath, xllOutputPath, compress, multithreading, overwrite, usageInfo, null, false);
+            int result = ExcelDna.PackedResources.ExcelDnaPack.Pack(dnaPath, xllOutputPath, compress, multithreading, overwrite, usageInfo, null, false, new ConsoleLogger(nameof(PackProgram)));
 
 #if DEBUG
             if (result == 0)

--- a/Source/Tests/ExcelDna.PackedResourcesTests/ExcelDna.PackedResourcesTests.csproj
+++ b/Source/Tests/ExcelDna.PackedResourcesTests/ExcelDna.PackedResourcesTests.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="AsmResolver.PE" Version="4.11.2" />
+    <PackageReference Include="FakeItEasy" Version="7.3.1" />
     <PackageReference Include="NUnit" Version="*" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.0-alpha-net7.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />

--- a/Source/Tests/ExcelDna.PackedResourcesTests/ExcelDnaPackTests.cs
+++ b/Source/Tests/ExcelDna.PackedResourcesTests/ExcelDnaPackTests.cs
@@ -1,4 +1,6 @@
 ﻿using ExcelDna.PackedResources;
+using ExcelDna.PackedResources.Logging;
+using FakeItEasy;
 using NUnit.Framework;
 using System.IO;
 
@@ -15,7 +17,7 @@ namespace ExcelDna.PackedResourcesTests
             string xllFile = TestdataHelper.FilePath("test_pack-AddIn.xll");
             string outPath = TestdataHelper.FilePath("ExcelDnaPackTests-AddIn64-packed-out.dll");
             File.Copy(TestdataHelper.FilePath("AddIn64-plain.dll"), xllFile, true);
-            ExcelDnaPack.Pack(dnaFile, outPath, true, false, true, null, null, useManagedResourceResolver);
+            ExcelDnaPack.Pack(dnaFile, outPath, true, false, true, null, null, useManagedResourceResolver, A.Dummy<IBuildLogger>());
 
             Assert.That(File.ReadAllBytes(outPath), Is.EqualTo(File.ReadAllBytes(TestdataHelper.FilePath(useManagedResourceResolver ? "AddIn64-packedX-plain.dll" : "AddIn64-packed-plain.dll"))));
             File.Delete(outPath);


### PR DESCRIPTION
Add build logging to help service #518 

Inject IBuildLogger to ExcelDnaPack.Pack and use it to log to the standard Build output instead of the console. ConsoleLogger added an implementation of the same for PackProgram.

Decoupled IBuildLogger from implementation and pull down to PackedResources so it can be reused, but kept the implementation unmoved from Addin.Tasks.Logging.