### PR TITLE
Implemented packing managed assemblies from deps.json

### DIFF
--- a/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.props
+++ b/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.props
@@ -3,5 +3,6 @@
 		<EnableDynamicLoading>true</EnableDynamicLoading>
 		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
 		<ExcelDnaPackNativeLibraryDependencies>false</ExcelDnaPackNativeLibraryDependencies>
+		<ExcelDnaPackManagedDependencies>false</ExcelDnaPackManagedDependencies>
 	</PropertyGroup>
 </Project>

--- a/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
+++ b/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
@@ -255,6 +255,7 @@
 		CompressResources="$(ExcelDnaPackCompressResources)"
 		RunMultithreaded="$(ExcelDnaPackRunMultithreaded)"
 		PackNativeLibraryDependencies="$(ExcelDnaPackNativeLibraryDependencies)"
+		PackManagedDependencies="$(ExcelDnaPackManagedDependencies)"
 		ExcludeDependencies="$(ExcelDnaPackExcludeDependencies)"
 		PackManagedOnWindows="$(ExcelDnaPackManagedResourcePackingOnWindows)"
 		SignTool="$(ExcelAddInSignTool)"

--- a/Source/ExcelDna.AddIn.Tasks/CreateExcelAddIn.cs
+++ b/Source/ExcelDna.AddIn.Tasks/CreateExcelAddIn.cs
@@ -394,7 +394,7 @@ namespace ExcelDna.AddIn.Tasks
                 return;
 
             List<string> filesToPublish = new List<string>();
-            int result = PackedResources.ExcelDnaPack.Pack(dnaPath, null, false, false, false, null, filesToPublish, false, null, false, null, _log);
+            int result = PackedResources.ExcelDnaPack.Pack(dnaPath, null, false, false, false, null, filesToPublish, false, false, null, false, null, _log);
             if (result != 0)
                 throw new ApplicationException($"Pack failed with exit code {result}.");
             foreach (string file in filesToPublish)

--- a/Source/ExcelDna.AddIn.Tasks/CreateExcelAddIn.cs
+++ b/Source/ExcelDna.AddIn.Tasks/CreateExcelAddIn.cs
@@ -419,7 +419,7 @@ namespace ExcelDna.AddIn.Tasks
                 return;
 
             ResourceHelper.ResourceUpdater ru = new ResourceHelper.ResourceUpdater(Path.Combine(Directory.GetCurrentDirectory(), xllPath), false, _log);
-            ru.AddFile(data, name, typeName, false, false);
+            ru.AddFile(data, name, typeName, null, false, false);
             ru.RemoveResource(compressedTypeName, name);
             ru.EndUpdate();
         }

--- a/Source/ExcelDna.AddIn.Tasks/PackExcelAddIn.cs
+++ b/Source/ExcelDna.AddIn.Tasks/PackExcelAddIn.cs
@@ -35,7 +35,7 @@ namespace ExcelDna.AddIn.Tasks
                 useManagedResourceResolver = PackManagedOnWindows || !OperatingSystem.IsWindows();
 #endif
 
-                int result = ExcelDna.PackedResources.ExcelDnaPack.Pack(OutputDnaFileName, OutputPackedXllFileName, CompressResources, RunMultithreaded, true, null, null, PackNativeLibraryDependencies, ExcludeDependencies, useManagedResourceResolver, OutputBitness, _log);
+                int result = ExcelDna.PackedResources.ExcelDnaPack.Pack(OutputDnaFileName, OutputPackedXllFileName, CompressResources, RunMultithreaded, true, null, null, PackNativeLibraryDependencies, PackManagedDependencies, ExcludeDependencies, useManagedResourceResolver, OutputBitness, _log);
                 if (result != 0)
                     throw new ApplicationException($"Pack failed with exit code {result}.");
 
@@ -120,6 +120,11 @@ namespace ExcelDna.AddIn.Tasks
         /// Enables packing native libraries from .deps.json
         /// </summary>
         public bool PackNativeLibraryDependencies { get; set; }
+
+        /// <summary>
+        /// Enables packing managed assemblies from .deps.json
+        /// </summary>
+        public bool PackManagedDependencies { get; set; }
 
         /// <summary>
         /// Semicolon separated file names list to not pack from .deps.json

--- a/Source/ExcelDna.PackedResources/ExcelDnaPack.cs
+++ b/Source/ExcelDna.PackedResources/ExcelDnaPack.cs
@@ -109,7 +109,7 @@ namespace ExcelDna.PackedResources
             if (File.Exists(configPath))
             {
                 if (filesToPublish == null)
-                    ru.AddFile(File.ReadAllBytes(configPath), "__MAIN__", ResourceHelper.TypeName.CONFIG, false, multithreading);  // Name here must exactly match name in ExcelDnaLoad.cpp.
+                    ru.AddFile(File.ReadAllBytes(configPath), "__MAIN__", ResourceHelper.TypeName.CONFIG, null, false, multithreading);  // Name here must exactly match name in ExcelDnaLoad.cpp.
                 else
                     filesToPublish.Add(configPath);
             }
@@ -122,7 +122,7 @@ namespace ExcelDna.PackedResources
                     if (dependenciesToExclude.Contains(Path.GetFileName(nativeLibrary), StringComparer.OrdinalIgnoreCase))
                         continue;
 
-                    ru.AddFile(File.ReadAllBytes(nativeLibrary), Path.GetFileName(nativeLibrary).ToUpperInvariant(), ResourceHelper.TypeName.NATIVE_LIBRARY, compress, multithreading);
+                    ru.AddFile(File.ReadAllBytes(nativeLibrary), Path.GetFileName(nativeLibrary).ToUpperInvariant(), ResourceHelper.TypeName.NATIVE_LIBRARY, "Native deps.json", compress, multithreading);
                 }
             }
 
@@ -130,7 +130,7 @@ namespace ExcelDna.PackedResources
             byte[] dnaContentForPacking = PackDnaLibrary(dnaPath, dnaBytes, dnaDirectory, ru, compress, multithreading, filesToPublish, packManagedDependencies, dependenciesToExclude, outputBitness, buildLogger);
             if (filesToPublish == null)
             {
-                ru.AddFile(dnaContentForPacking, "__MAIN__", ResourceHelper.TypeName.DNA, false, multithreading); // Name here must exactly match name in DnaLibrary.Initialize.
+                ru.AddFile(dnaContentForPacking, "__MAIN__", ResourceHelper.TypeName.DNA, null, false, multithreading); // Name here must exactly match name in DnaLibrary.Initialize.
                 ru.EndUpdate();
             }
             else
@@ -182,7 +182,7 @@ namespace ExcelDna.PackedResources
                             byte[] dnaContentForPacking = PackDnaLibrary(path, File.ReadAllBytes(path), Path.GetDirectoryName(path), ru, compress, multithreading, filesToPublish, false, null, outputBitness, buildLogger);
                             if (filesToPublish == null)
                             {
-                                ru.AddFile(dnaContentForPacking, name, ResourceHelper.TypeName.DNA, compress, multithreading);
+                                ru.AddFile(dnaContentForPacking, name, ResourceHelper.TypeName.DNA, null, compress, multithreading);
                                 ext.Path = "packed:" + name;
                             }
                             else
@@ -194,7 +194,7 @@ namespace ExcelDna.PackedResources
                         {
                             if (filesToPublish == null)
                             {
-                                string packedName = ru.AddAssembly(path, compress, multithreading, ext.IncludePdb);
+                                string packedName = ru.AddAssembly(path, null, compress, multithreading, ext.IncludePdb);
                                 if (packedName != null)
                                 {
                                     ext.Path = "packed:" + packedName;
@@ -352,7 +352,7 @@ namespace ExcelDna.PackedResources
                     // It worked!
                     if (filesToPublish == null)
                     {
-                        string packedName = ru.AddAssembly(path, compress, multithreading, rf.IncludePdb);
+                        string packedName = ru.AddAssembly(path, null, compress, multithreading, rf.IncludePdb);
                         if (packedName != null)
                         {
                             rf.Path = "packed:" + packedName;
@@ -381,7 +381,7 @@ namespace ExcelDna.PackedResources
                     {
                         string name = Path.GetFileNameWithoutExtension(path).ToUpperInvariant() + "_" + lastPackIndex++ + Path.GetExtension(path).ToUpperInvariant();
                         byte[] imageBytes = File.ReadAllBytes(path);
-                        ru.AddFile(imageBytes, name, ResourceHelper.TypeName.IMAGE, compress, multithreading);
+                        ru.AddFile(imageBytes, name, ResourceHelper.TypeName.IMAGE, null, compress, multithreading);
                         image.Path = "packed:" + name;
                     }
                     else
@@ -408,7 +408,7 @@ namespace ExcelDna.PackedResources
                         {
                             string name = Path.GetFileNameWithoutExtension(path).ToUpperInvariant() + "_" + lastPackIndex++ + Path.GetExtension(path).ToUpperInvariant();
                             byte[] sourceBytes = File.ReadAllBytes(path);
-                            ru.AddFile(sourceBytes, name, ResourceHelper.TypeName.SOURCE, compress, multithreading);
+                            ru.AddFile(sourceBytes, name, ResourceHelper.TypeName.SOURCE, null, compress, multithreading);
                             source.Path = "packed:" + name;
                         }
                         else
@@ -426,7 +426,7 @@ namespace ExcelDna.PackedResources
                     if (dependenciesToExclude.Contains(Path.GetFileName(assembly), StringComparer.OrdinalIgnoreCase))
                         continue;
 
-                    ru.AddAssembly(assembly, compress, multithreading, false);
+                    ru.AddAssembly(assembly, "Managed deps.json", compress, multithreading, false);
                 }
             }
 

--- a/Source/ExcelDna.PackedResources/ExcelDnaPack.cs
+++ b/Source/ExcelDna.PackedResources/ExcelDnaPack.cs
@@ -10,7 +10,7 @@ namespace ExcelDna.PackedResources
 {
     internal class ExcelDnaPack
     {
-        public static int Pack(string dnaPath, string xllOutputPathParam, bool compress, bool multithreading, bool overwrite, string usageInfo, List<string> filesToPublish, bool packNativeLibraryDependencies, string excludeDependencies, bool useManagedResourceResolver, string outputBitness, IBuildLogger buildLogger)
+        public static int Pack(string dnaPath, string xllOutputPathParam, bool compress, bool multithreading, bool overwrite, string usageInfo, List<string> filesToPublish, bool packNativeLibraryDependencies, bool packManagedDependencies, string excludeDependencies, bool useManagedResourceResolver, string outputBitness, IBuildLogger buildLogger)
         {
             string dnaDirectory = Path.GetDirectoryName(dnaPath);
             string dnaFilePrefix = Path.GetFileNameWithoutExtension(dnaPath);

--- a/Source/ExcelDna.PackedResources/ResourceHelper.cs
+++ b/Source/ExcelDna.PackedResources/ResourceHelper.cs
@@ -128,17 +128,17 @@ internal static class ResourceHelper
             resourceResolver.Begin(fileName);
         }
 
-        private void CompressDoUpdateHelper(byte[] content, string name, TypeName typeName, bool compress)
+        private void CompressDoUpdateHelper(byte[] content, string name, TypeName typeName, string source, bool compress)
         {
             if (compress)
             {
                 content = SevenZipHelper.Compress(content);
             }
 
-            DoUpdateResource(typeName.ToString() + (compress ? "_LZMA" : ""), name, content);
+            DoUpdateResource(typeName.ToString() + (compress ? "_LZMA" : ""), name, source, content);
         }
 
-        public string AddFile(byte[] content, string name, TypeName typeName, bool compress, bool multithreading)
+        public string AddFile(byte[] content, string name, TypeName typeName, string source, bool compress, bool multithreading)
         {
             Debug.Assert(name == name.ToUpperInvariant());
 
@@ -148,20 +148,20 @@ internal static class ResourceHelper
                 finishedTask.Enqueue(mre);
                 ThreadPool.QueueUserWorkItem(delegate
                 {
-                    CompressDoUpdateHelper(content, name, typeName, compress);
+                    CompressDoUpdateHelper(content, name, typeName, source, compress);
                     mre.Set();
                 }
                 );
             }
             else
             {
-                CompressDoUpdateHelper(content, name, typeName, compress);
+                CompressDoUpdateHelper(content, name, typeName, source, compress);
             }
 
             return name;
         }
 
-        public string AddAssembly(string path, bool compress, bool multithreading, bool includePdb)
+        public string AddAssembly(string path, string source, bool compress, bool multithreading, bool includePdb)
         {
             try
             {
@@ -179,13 +179,13 @@ internal static class ResourceHelper
                     name += "." + cultureInfo.Name.ToUpperInvariant();
                 }
 
-                AddFile(assemblyBytes, name, TypeName.ASSEMBLY, compress, multithreading);
+                AddFile(assemblyBytes, name, TypeName.ASSEMBLY, source, compress, multithreading);
 
                 string pdbFile = Path.ChangeExtension(path, "pdb");
                 if (includePdb && File.Exists(pdbFile))
                 {
                     byte[] pdbBytes = File.ReadAllBytes(pdbFile);
-                    AddFile(pdbBytes, name, TypeName.PDB, compress, multithreading);
+                    AddFile(pdbBytes, name, TypeName.PDB, source, compress, multithreading);
                 }
 
                 return name;
@@ -218,11 +218,12 @@ internal static class ResourceHelper
             return typelibIndex;
         }
 
-        public void DoUpdateResource(string typeName, string name, byte[] data)
+        public void DoUpdateResource(string typeName, string name, string source, byte[] data)
         {
             lock (lockResource)
             {
-                buildLogger.Information("  ->  Updating resource: Type: {0}, Name: {1}, Length: {2}", typeName, name, data.Length);
+                string sourceInfo = (source != null) ? $" Source: {source}," : null;
+                buildLogger.Information($"  ->  Updating resource: Type: {typeName}, Name: {name},{sourceInfo} Length: {data.Length}");
 
                 bool result = resourceResolver.Update(typeName, name, localeNeutral, data);
                 if (!result)

--- a/Source/ExcelDnaPack/PackProgram.cs
+++ b/Source/ExcelDnaPack/PackProgram.cs
@@ -151,9 +151,9 @@ Other assemblies are packed if marked with Pack=""true"" in the .dna file.
             ResourceHelper.ResourceUpdater ru = new ResourceHelper.ResourceUpdater(xllFullPath, false, buildLogger);
 
             var xllDir = Path.GetDirectoryName(xllFullPath);
-            ru.AddAssembly(Path.Combine(xllDir, "ExcelDna.ManagedHost.dll"), compress: false, multithreading: false, includePdb);
-            ru.AddAssembly(Path.Combine(xllDir, "ExcelDna.Loader.dll"), compress: true, multithreading: false, includePdb);
-            ru.AddAssembly(Path.Combine(xllDir, "ExcelDna.Integration.dll"), compress: true, multithreading: false, includePdb);
+            ru.AddAssembly(Path.Combine(xllDir, "ExcelDna.ManagedHost.dll"), null, compress: false, multithreading: false, includePdb);
+            ru.AddAssembly(Path.Combine(xllDir, "ExcelDna.Loader.dll"), null, compress: true, multithreading: false, includePdb);
+            ru.AddAssembly(Path.Combine(xllDir, "ExcelDna.Integration.dll"), null, compress: true, multithreading: false, includePdb);
             ru.EndUpdate();
         }
     }

--- a/Source/ExcelDnaPack/PackProgram.cs
+++ b/Source/ExcelDnaPack/PackProgram.cs
@@ -127,7 +127,7 @@ Other assemblies are packed if marked with Pack=""true"" in the .dna file.
                 }
             }
 
-            int result = ExcelDna.PackedResources.ExcelDnaPack.Pack(dnaPath, xllOutputPath, compress, multithreading, overwrite, usageInfo, null, false, null, false, null, buildLogger);
+            int result = ExcelDna.PackedResources.ExcelDnaPack.Pack(dnaPath, xllOutputPath, compress, multithreading, overwrite, usageInfo, null, false, false, null, false, null, buildLogger);
 
 #if DEBUG
             if (result == 0)

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/NET6PackDeps/NET6PackDeps.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/NET6PackDeps/NET6PackDeps.csproj
@@ -5,8 +5,8 @@
     <UseWindowsForms>True</UseWindowsForms>
     
     <EnableDynamicLoading>true</EnableDynamicLoading>
-    <ExcelAddInInclude>runtimes/win/lib/net6.0/System.Management.dll;System.Data.SQLite.dll</ExcelAddInInclude>
     <ExcelDnaPackNativeLibraryDependencies>true</ExcelDnaPackNativeLibraryDependencies>
+    <ExcelDnaPackManagedDependencies>true</ExcelDnaPackManagedDependencies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SDKProperties/SDKProperties.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SDKProperties/SDKProperties.csproj
@@ -97,6 +97,10 @@
     <!-- Default value: false -->
     <ExcelDnaPackNativeLibraryDependencies></ExcelDnaPackNativeLibraryDependencies>
 
+    <!-- Enables packing managed assemblies from .deps.json. -->
+    <!-- Default value: false -->
+    <ExcelDnaPackManagedDependencies></ExcelDnaPackManagedDependencies>
+
     <!-- Semicolon separated file names list to not pack from .deps.json. -->
     <!-- Default value: empty -->
     <ExcelDnaPackExcludeDependencies></ExcelDnaPackExcludeDependencies>

--- a/Source/Tests/ExcelDna.PackedResourcesTests/ExcelDnaPackTests.cs
+++ b/Source/Tests/ExcelDna.PackedResourcesTests/ExcelDnaPackTests.cs
@@ -17,7 +17,7 @@ namespace ExcelDna.PackedResourcesTests
             string xllFile = TestdataHelper.FilePath("test_pack-AddIn.xll");
             string outPath = TestdataHelper.FilePath("ExcelDnaPackTests-AddIn64-packed-out.dll");
             File.Copy(TestdataHelper.FilePath("AddIn64-compressed.dll"), xllFile, true);
-            ExcelDnaPack.Pack(dnaFile, outPath, true, false, true, null, null, false, null, useManagedResourceResolver, null, A.Dummy<IBuildLogger>());
+            ExcelDnaPack.Pack(dnaFile, outPath, true, false, true, null, null, false, false, null, useManagedResourceResolver, null, A.Dummy<IBuildLogger>());
 
             Assert.That(File.ReadAllBytes(outPath), Is.EqualTo(File.ReadAllBytes(TestdataHelper.FilePath(useManagedResourceResolver ? "AddIn64-packedX-compressed.dll" : "AddIn64-packed-compressed.dll"))));
             File.Delete(outPath);


### PR DESCRIPTION
1. The build task logs which files we are including according to the .deps.json information as Source:

>   PackExcelAddIn:   ->  Updating resource: Type: DNA, Name: __MAIN__, Length: 555
>   PackExcelAddIn:   ->  Updating resource: Type: ASSEMBLY_LZMA, Name: NET6PACKDEPS, Length: 2523
>   PackExcelAddIn:   ->  Updating resource: Type: ASSEMBLY_LZMA, Name: SYSTEM.MANAGEMENT, Source: Managed deps.json, Length: 83824
>   PackExcelAddIn:   ->  Updating resource: Type: ASSEMBLY_LZMA, Name: SYSTEM.DATA.SQLITE, Source: Managed deps.json, Length: 119610
>   PackExcelAddIn:   ->  Updating resource: Type: NATIVE_LIBRARY_LZMA, Name: SQLITE.INTEROP.DLL, Source: Native deps.json, Length: 765473

2. A managed dependency with a Runtime ID overrides a dependency without one. E.g. "win runtimes/win/lib/net6.0/System.Management.dll" is used instead of "lib/net6.0/System.Management.dll".