### PR TITLE
Added Source Link support for ExcelDna.Integration package

### DIFF
--- a/Build/BuildPackages.bat
+++ b/Build/BuildPackages.bat
@@ -8,10 +8,10 @@ set rcfile=..\Source\versioninfo.rc2
 PowerShell "(Get-Content %rcfile%) -replace '\d+,\d+,\d+,\d+', '%DllVersion%'.Replace('.',',') -replace '\d+\.\d+\.\d+\.\d+', '%DllVersion%' | Set-Content %rcfile%"
 @if errorlevel 1 goto end
 
-%MSBuildPath% ..\Source\ExcelDna.sln /t:restore,build /p:Configuration=Release
+%MSBuildPath% ..\Source\ExcelDna.sln /t:restore,build /p:Configuration=Release /p:ContinuousIntegrationBuild=true
 @if errorlevel 1 goto end
 
-%MSBuildPath% ..\Source\ExcelDna.sln /t:restore,build /p:Configuration=Release /p:Platform=x64
+%MSBuildPath% ..\Source\ExcelDna.sln /t:restore,build /p:Configuration=Release /p:Platform=x64 /p:ContinuousIntegrationBuild=true
 @if errorlevel 1 goto end
 
 call build.bat

--- a/Build/build.bat
+++ b/Build/build.bat
@@ -8,8 +8,10 @@ copy /Y ..\Source\ExcelDna.Host\bin\Release\x64\ExcelDna.Host.x64.xll ..\Distrib
 
 copy /Y ..\Source\ExcelDna.Integration\bin\Release\net452\ExcelDna.Integration.dll ..\Distribution\net452\
 copy /Y ..\Source\ExcelDna.Integration\bin\Release\net452\ExcelDna.Integration.xml ..\Distribution\net452\
+copy /Y ..\Source\ExcelDna.Integration\bin\Release\net452\ExcelDna.Integration.pdb ..\Distribution\net452\
 copy /Y ..\Source\ExcelDna.Integration\bin\Release\net6.0-windows\ExcelDna.Integration.dll ..\Distribution\net6.0-windows\
 copy /Y ..\Source\ExcelDna.Integration\bin\Release\net6.0-windows\ExcelDna.Integration.xml ..\Distribution\net6.0-windows\
+copy /Y ..\Source\ExcelDna.Integration\bin\Release\net6.0-windows\ExcelDna.Integration.pdb ..\Distribution\net6.0-windows\
 
 copy /Y ..\Source\ExcelDnaPack\bin\Release\net452\ExcelDnaPack.exe ..\Distribution\net452\
 copy /Y ..\Source\ExcelDnaPack\bin\Release\net452\ExcelDnaPack.exe.config ..\Distribution\net452\

--- a/MasterBuild/Directory.Build.props
+++ b/MasterBuild/Directory.Build.props
@@ -4,4 +4,15 @@
     <FileVersion>_VERSION_</FileVersion>
     <InformationalVersion>_VERSION_</InformationalVersion>
  </PropertyGroup>
+
+ <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+ </PropertyGroup>
+
+ <ItemGroup Condition="$(MSBuildProjectExtension)=='.csproj'">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+ </ItemGroup>
 </Project>

--- a/Package/ExcelDna.Integration/ExcelDna.Integration.nuspec
+++ b/Package/ExcelDna.Integration/ExcelDna.Integration.nuspec
@@ -21,8 +21,10 @@
     <files>
         <file src="..\..\Distribution\net452\ExcelDna.Integration.dll" target="lib\net452\ExcelDna.Integration.dll" />
         <file src="..\..\Distribution\net452\ExcelDna.Integration.xml" target="lib\net452\ExcelDna.Integration.xml" />
+        <file src="..\..\Distribution\net452\ExcelDna.Integration.pdb" target="lib\net452\ExcelDna.Integration.pdb" />
         <file src="..\..\Distribution\net6.0-windows\ExcelDna.Integration.dll" target="lib\net6.0-windows7.0\ExcelDna.Integration.dll" />
         <file src="..\..\Distribution\net6.0-windows\ExcelDna.Integration.xml" target="lib\net6.0-windows7.0\ExcelDna.Integration.xml" />
+        <file src="..\..\Distribution\net6.0-windows\ExcelDna.Integration.pdb" target="lib\net6.0-windows7.0\ExcelDna.Integration.pdb" />
       <file src="..\images\ExcelDna-nu.png" target="images\" />
     </files>
 </package>

--- a/Package/package.cmd
+++ b/Package/package.cmd
@@ -18,7 +18,7 @@ nuget.exe pack "%basePath%\ExcelDna.Templates\ExcelDna.Templates.nuspec" -BasePa
 nuget.exe pack "%basePath%\ExcelDna.AddIn\ExcelDna.AddIn.nuspec" -BasePath "%basePath%\ExcelDna.AddIn" -OutputDirectory "%outputPath%" -Verbosity detailed -NonInteractive -Prop ExcelDnaVersion="%ExcelDnaVersion%"
 @if errorlevel 1 goto end
 
-nuget.exe pack "%basePath%\ExcelDna.Integration\ExcelDna.Integration.nuspec" -BasePath "%basePath%\ExcelDna.Integration" -OutputDirectory "%outputPath%" -Verbosity detailed -NonInteractive -Prop ExcelDnaVersion="%ExcelDnaVersion%"
+nuget.exe pack "%basePath%\ExcelDna.Integration\ExcelDna.Integration.nuspec" -BasePath "%basePath%\ExcelDna.Integration" -OutputDirectory "%outputPath%" -Verbosity detailed -NonInteractive -Prop ExcelDnaVersion="%ExcelDnaVersion%" -Symbols -SymbolPackageFormat snupkg
 @if errorlevel 1 goto end
 
 nuget.exe pack "%basePath%\ExcelDna.XmlSchemas\ExcelDna.XmlSchemas.nuspec" -BasePath "%basePath%\ExcelDna.XmlSchemas" -OutputDirectory "%outputPath%" -Verbosity detailed -NonInteractive


### PR DESCRIPTION
1. I can't locally test how it works (without pushing to NuGet servers) -  VS doesn't support local .snupkg.

2. ExcelDna.Integration.1.6.1-beta2.snupkg with .pdb files is now additionally created in the nupkg directory. See [Publishing a symbol package](https://learn.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg#publishing-a-symbol-package) for publishing.