### PR TITLE
Add '/x64' option to ExcelDnaPack

### DIFF
--- a/Source/ExcelDna.PackedResources/ExcelDnaPack.cs
+++ b/Source/ExcelDna.PackedResources/ExcelDnaPack.cs
@@ -12,6 +12,7 @@ namespace ExcelDna.PackedResources
     {
         public static int Pack(string dnaPath, string xllOutputPathParam, bool compress, bool multithreading, bool overwrite, string usageInfo, List<string> filesToPublish, bool packNativeLibraryDependencies, bool packManagedDependencies, string excludeDependencies, bool useManagedResourceResolver, string outputBitness, IBuildLogger buildLogger)
         {
+            string HostXLL = outputBitness == "64" ? "ExcelDna64.xll" : "ExcelDna.xll";
             string dnaDirectory = Path.GetDirectoryName(dnaPath);
             string dnaFilePrefix = Path.GetFileNameWithoutExtension(dnaPath);
             string configPath = Path.ChangeExtension(dnaPath, ".xll.config");
@@ -75,11 +76,11 @@ namespace ExcelDna.PackedResources
             {
                 // CONSIDER: Maybe the next two (old) search locations should be deprecated?
                 // Then try one called ExcelDna.xll next to the .dna file
-                xllInputPath = Path.Combine(dnaDirectory, "ExcelDna.xll");
+                xllInputPath = Path.Combine(dnaDirectory, HostXLL);
                 if (!File.Exists(xllInputPath))
                 {
                     // Then try one called ExcelDna.xll next to the ExcelDnaPack.exe
-                    xllInputPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ExcelDna.xll");
+                    xllInputPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, HostXLL);
                     if (!File.Exists(xllInputPath))
                     {
                         buildLogger.Error(typeof(ExcelDnaPack), "ERROR: Base add-in not found.\r\n\r\n {0}", usageInfo);

--- a/Source/ExcelDnaPack/PackProgram.cs
+++ b/Source/ExcelDnaPack/PackProgram.cs
@@ -94,6 +94,7 @@ Other assemblies are packed if marked with Pack=""true"" in the .dna file.
             bool overwrite = false;
             bool compress = true;
             bool multithreading = true;
+            string outputBitness = "32";
 
             // TODO: Replace with an args-parsing routine.
             if (args.Length > 1)
@@ -124,10 +125,15 @@ Other assemblies are packed if marked with Pack=""true"" in the .dna file.
                     {
                         multithreading = false;
                     }
+                    else
+                    if (args[i].Equals("/x64", StringComparison.CurrentCultureIgnoreCase))
+                    {
+                        outputBitness = "64";
+                    }
                 }
             }
 
-            int result = ExcelDna.PackedResources.ExcelDnaPack.Pack(dnaPath, xllOutputPath, compress, multithreading, overwrite, usageInfo, null, false, false, null, false, null, buildLogger);
+            int result = ExcelDna.PackedResources.ExcelDnaPack.Pack(dnaPath, xllOutputPath, compress, multithreading, overwrite, usageInfo, null, false, false, null, false, outputBitness, buildLogger);
 
 #if DEBUG
             if (result == 0)


### PR DESCRIPTION
Add the '/x64' command line option to ExcelDnaPack to select the correct generic ExcelDna.xll without renaming it.