### PR TITLE
Startup reliability

### DIFF
--- a/Source/ExcelDna.Host/host.cpp
+++ b/Source/ExcelDna.Host/host.cpp
@@ -176,9 +176,14 @@ int load_runtime_and_run(const std::wstring& basePath, XlAddInExportInfo* pExpor
 void* load_library(const char_t* path)
 {
 	HMODULE h = ::LoadLibraryW(path);
-	assert(h != nullptr);
+	if (h == nullptr)
+	{
+		ShowHostError(std::format(L"Loading library {} failed.", path));
+		return nullptr;
+	}
 	return (void*)h;
 }
+
 void* get_export(void* h, const char* name)
 {
 	void* f = ::GetProcAddress((HMODULE)h, name);
@@ -198,6 +203,9 @@ bool load_hostfxr(int& rc)
 
 	// Load hostfxr and get desired exports
 	void* lib = load_library(buffer);
+	if (lib == nullptr)
+		return false;
+
 	init_fptr = (hostfxr_initialize_for_runtime_config_fn)get_export(lib, "hostfxr_initialize_for_runtime_config");
 	get_delegate_fptr = (hostfxr_get_runtime_delegate_fn)get_export(lib, "hostfxr_get_runtime_delegate");
 	get_property_fptr = (hostfxr_get_runtime_property_value_fn)get_export(lib, "hostfxr_get_runtime_property_value");

--- a/Source/ExcelDna.Loader/XlAddIn.cs
+++ b/Source/ExcelDna.Loader/XlAddIn.cs
@@ -274,21 +274,18 @@ namespace ExcelDna.Loader
                 ExcelIntegration.DnaLibraryAutoOpen();
 
                 result = 1; // All is OK
+
+                // Clear the status bar message
+                XlCallImpl.TryExcelImpl(XlCallImpl.xlcMessage, out xlCallResult /*Ignored*/ , false);
+                // Debug.Print("Clear status bar message result: " + xlCallResult);
             }
             catch (Exception e)
             {
-                // Can't use logging here
-                string alertMessage = string.Format("A problem occurred while an add-in was being initialized (InitializeIntegration failed - {1}).\r\nThe add-in is built with ExcelDna and is being loaded from {0}", PathXll, e.Message);
+                // Can't use logging, xlcAlert and xlcMessage with length >220 here
+                string message = string.Format("ExcelDna add-in InitializeIntegration failed - {1} - {0}", PathXll, e.Message);
                 object xlCallResult;
-                XlCallImpl.TryExcelImpl(XlCallImpl.xlcAlert, out xlCallResult /*Ignored*/, alertMessage, 3 /* Only OK Button, Warning Icon*/);
+                XlCallImpl.TryExcelImpl(XlCallImpl.xlcMessage, out xlCallResult /*Ignore*/ , true, message.Substring(0, 220));
                 result = 0;
-            }
-            finally
-            {
-                // Clear the status bar message
-                object xlCallResult;
-                XlCallImpl.TryExcelImpl(XlCallImpl.xlcMessage, out xlCallResult /*Ignored*/ , false);
-                // Debug.Print("Clear status bar message result: " + xlCallResult);
             }
             return result;
         }


### PR DESCRIPTION
1. Added a descriptive message for FrameworkMissingFailure error.

2. Replaced more assert messages in ExcelDna.Host with traditional message box errors including error codes.

3. Fixed XlAutoOpen error message display.

4. Changed required .NET runtime to v6.0.2.