### PR TITLE
Add functionality to pack and retrieve arbitrary files specified in .dna

### DIFF
--- a/Distribution/XmlSchemas/ExcelDna.DnaLibrary.xsd
+++ b/Distribution/XmlSchemas/ExcelDna.DnaLibrary.xsd
@@ -206,6 +206,22 @@
     </xs:simpleContent>
   </xs:complexType>
 
+  <xs:complexType name="FileType">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="Name"
+                      use="required"
+                      type="xs:string" />
+        <xs:attribute name="Path"
+                      use="required"
+                      type="xs:string" />
+        <xs:attribute name="Pack"
+                      use="optional"
+                      type="Boolean" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
   <xs:complexType name="CustomUIType">
     <xs:sequence>
       <xs:any maxOccurs="unbounded"
@@ -239,6 +255,11 @@
                     maxOccurs="unbounded"
                     minOccurs="0"
                     type="ImageType">
+        </xs:element>
+        <xs:element name="File"
+                    maxOccurs="unbounded"
+                    minOccurs="0"
+                    type="FileType">
         </xs:element>
         <xs:element name="CustomUI"
                     maxOccurs="unbounded"

--- a/Source/ExcelDna.Integration/DnaLibrary.cs
+++ b/Source/ExcelDna.Integration/DnaLibrary.cs
@@ -202,6 +202,14 @@ namespace ExcelDna.Integration
             set { _Images = value; }
         }
 
+        private List<DnaFile> _Files;
+        [XmlElement("File", typeof(DnaFile))]
+        public List<DnaFile> Files
+        {
+            get { return _Files; }
+            set { _Files = value; }
+        }
+
         private string dnaResolveRoot;
 
         // Get projects explicit and implicitly present in the library
@@ -721,6 +729,40 @@ namespace ExcelDna.Integration
                         }
                         Logger.Initialization.Warn("DnaLibrary.GetImage - Image {0} read from {1} was not a bitmap!?", image.Name, image.Path);
                     }
+                }
+            }
+            return null;
+        }
+
+        public byte[] GetFileBytes(string fileId)
+        {
+            // TODO: Consider if this should be a Stream instead of a byte[]
+            // This would allow for larger files to be handled more efficiently.
+
+            // First check if fileId is in the DnaLibrary's File list.
+            // DOCUMENT: Case sensitive match.
+            foreach (DnaFile file in Files)
+            {
+                if (file.Name == fileId && file.Path != null)
+                {
+                    byte[] fileBytes;
+                    if (file.Path.StartsWith("packed:"))
+                    {
+                        string resourceName = file.Path.Substring(7);
+                        fileBytes = ExcelIntegration.GetFileBytes(resourceName);
+                    }
+                    else
+                    {
+                        string filePath = ResolvePath(file.Path);
+                        if (filePath == null)
+                        {
+                            // This is the file but we could not find it !?
+                            Logger.Initialization.Warn("DnaLibrary.GetFile - For file {0} the path resolution failed: {1}", file.Name, file.Path);
+                            return null;
+                        }
+                        fileBytes = File.ReadAllBytes(filePath);
+                    }
+                    return fileBytes;
                 }
             }
             return null;

--- a/Source/ExcelDna.Integration/Excel.cs
+++ b/Source/ExcelDna.Integration/Excel.cs
@@ -11,6 +11,8 @@ using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace ExcelDna.Integration
 {
@@ -780,6 +782,23 @@ namespace ExcelDna.Integration
                 }
                 return _supportsDynamicArrays.Value;
             }
+        }
+        #endregion
+
+        #region Packed Files
+        /// <summary>Returns the names of all the resources packed in the XLL.</summary>
+        /// <returns>An enumerable that contains the names of all the resources.</returns>
+        public static IEnumerable<string> GetPackedFileNames()
+        {
+            return DnaLibrary.CurrentLibrary.Files.Select(f => f.Name);
+        }
+
+        /// <summary>Loads the specified resource from the XLL.</summary>
+        /// <param name="name">The case-sensitive name of the resource being requested.</param>
+        /// <returns>The resource; or <see langword="null" /> if the resource does not exist in the XLL.</returns>
+        public static byte[] GetPackedFileBytes(string name)
+        {
+            return DnaLibrary.CurrentLibrary.GetFileBytes(name);
         }
         #endregion
     }

--- a/Source/ExcelDna.Integration/ExcelIntegration.cs
+++ b/Source/ExcelDna.Integration/ExcelIntegration.cs
@@ -183,6 +183,11 @@ namespace ExcelDna.Integration
             return _integrationHost.GetResourceBytes(imageName, 2);
         }
 
+        internal static byte[] GetFileBytes(string fileName)
+        {
+            return _integrationHost.GetResourceBytes(fileName, 2);
+        }
+
         internal static byte[] GetSourceBytes(string sourceName)
         {
             return _integrationHost.GetResourceBytes(sourceName, 3);

--- a/Source/ExcelDna.Integration/IIntegrationHost.cs
+++ b/Source/ExcelDna.Integration/IIntegrationHost.cs
@@ -8,7 +8,7 @@ namespace ExcelDna.Integration
     interface IIntegrationHost
     {
         XlCall.XlReturn TryExcelImpl(int xlFunction, out object result, params object[] parameters);
-        byte[] GetResourceBytes(string resourceName, int type); // types: 0 - Assembly, 1 - Dna file, 2 - Image
+        byte[] GetResourceBytes(string resourceName, int type); // types: 0 - Assembly, 1 - Dna file, 2 - Image or File, 3 - Source, 4 - PDB
         Assembly LoadFromAssemblyPath(string assemblyPath);
         Assembly LoadFromAssemblyBytes(byte[] assemblyBytes, byte[] pdbBytes);
         void RegisterMethods(List<MethodInfo> methods);

--- a/Source/ExcelDna.Integration/Reference.cs
+++ b/Source/ExcelDna.Integration/Reference.cs
@@ -53,7 +53,7 @@ namespace ExcelDna.Integration
         {
             Path = path;
         }
-	}
+    }
 
     [Serializable]
     [XmlType(AnonymousType = true)]
@@ -69,6 +69,24 @@ namespace ExcelDna.Integration
         public bool Pack;
 
         public Image()
+        {
+        }
+    }
+
+    [Serializable]
+    [XmlType(AnonymousType = true)]
+    public class DnaFile
+    {
+        [XmlAttribute]
+        public string Name;
+
+        [XmlAttribute]
+        public string Path;
+
+        [XmlAttribute]
+        public bool Pack;
+
+        public DnaFile()
         {
         }
     }

--- a/Source/ExcelDna.PackedResources/ExcelDnaPack.cs
+++ b/Source/ExcelDna.PackedResources/ExcelDnaPack.cs
@@ -402,6 +402,31 @@ namespace ExcelDna.PackedResources
                     }
                 }
             }
+            foreach (DnaFile file in dna.Files)
+            {
+                if (file.Pack)
+                {
+                    string path = dna.ResolvePath(file.Path);
+                    if (path == null)
+                    {
+                        var format = "  ~~> ERROR: File path {0} NOT RESOLVED.";
+                        errorMessage = string.Format(format, file.Path);
+                        buildLogger.Error(typeof(ExcelDnaPack), format, file.Path);
+                        throw new InvalidOperationException(errorMessage);
+                    }
+                    if (filesToPublish == null)
+                    {
+                        string name = Path.GetFileNameWithoutExtension(path).ToUpperInvariant() + "_" + lastPackIndex++ + Path.GetExtension(path).ToUpperInvariant();
+                        byte[] fileBytes = File.ReadAllBytes(path);
+                        ru.AddFile(fileBytes, name, ResourceHelper.TypeName.FILE, null, compress, multithreading);
+                        file.Path = "packed:" + name;
+                    }
+                    else
+                    {
+                        filesToPublish.Add(path);
+                    }
+                }
+            }
             foreach (Project project in dna.Projects)
             {
                 foreach (SourceItem source in project.SourceItems)

--- a/Source/ExcelDna.PackedResources/ResourceHelper.cs
+++ b/Source/ExcelDna.PackedResources/ResourceHelper.cs
@@ -25,6 +25,7 @@ internal static class ResourceHelper
         SOURCE = 3,
         PDB = 4,
         NATIVE_LIBRARY = 5,
+        FILE = 6,
     }
 
     // TODO: Learn about locales


### PR DESCRIPTION
Hi @govert 

This PR is my attempt to address #331 and adds a `File` element type to the .dna schema as well as the corresponding code to pack and unpack the files. 

By inspection, this code should achieve this, however, I am not sure of the process to generate tests to ensure that this code is working as expected. It looks like the packing tests rely on known-good binary files, what do I need to do to create one of these files with an embedded file?

The main changes are:

- Adds new `FileType` to the DnaLibrary xsd schema
- Adds new `DnaFile` class for xml serialization
- Adds new API `public static IEnumerable<string> ExcelDnaUtil.GetPackedFileNames()`
- Adds new API `public static byte[] ExcelDnaUtil.GetPackedFileBytes(string name)`

