### PR TITLE
Implemented packing a .chm help file

### DIFF
--- a/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
+++ b/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
@@ -282,6 +282,7 @@
 		OutputDnaFileName="%(ExcelDnaFilesToPack.OutputDnaFileName)"
 		OutputPackedXllFileName="%(ExcelDnaFilesToPack.OutputPackedXllFileName)"
 		OutputBitness="%(ExcelDnaFilesToPack.OutputBitness)"
+		DocPath="%(ExcelDnaFilesToPack.DocPath)"
 		CompressResources="$(ExcelDnaPackCompressResources)"
 		RunMultithreaded="$(ExcelDnaPackRunMultithreaded)"
 		PackNativeLibraryDependencies="$(ExcelDnaPackNativeLibraryDependencies)"

--- a/Source/ExcelDna.AddIn.Tasks/CreateExcelAddIn.cs
+++ b/Source/ExcelDna.AddIn.Tasks/CreateExcelAddIn.cs
@@ -54,7 +54,8 @@ namespace ExcelDna.AddIn.Tasks
 
                 TryCreateTlb();
 
-                TryPublishDoc();
+                if (UnpackIsEnabled)
+                    TryPublishDoc();
 
                 TryBuildAddInFor32Bit(buildItemsForDnaFiles);
 
@@ -152,9 +153,8 @@ namespace ExcelDna.AddIn.Tasks
 
         private void TryPublishDoc()
         {
-            string docFile = (AddInFileName ?? ProjectName + "-AddIn") + ".chm";
-            string docFilePath = Path.Combine(OutDirectory, docFile);
-            if (!File.Exists(docFilePath))
+            string docFilePath = GetDocPath();
+            if (docFilePath == null)
                 return;
 
             if (PackExcelAddIn.NoPublishPath(PublishPath))
@@ -162,7 +162,14 @@ namespace ExcelDna.AddIn.Tasks
 
             string destinationFolder = PackExcelAddIn.GetPublishDirectory(OutDirectory, PublishPath);
             Directory.CreateDirectory(destinationFolder);
-            File.Copy(docFilePath, Path.Combine(destinationFolder, docFile), true);
+            File.Copy(docFilePath, Path.Combine(destinationFolder, Path.GetFileName(docFilePath)), true);
+        }
+
+        private string GetDocPath()
+        {
+            string docFile = (AddInFileName ?? ProjectName + "-AddIn") + ".chm";
+            string docFilePath = Path.Combine(OutDirectory, docFile);
+            return File.Exists(docFilePath) ? docFilePath : null;
         }
 
         private ITaskItem[] GetConfigFilesInProject()
@@ -359,6 +366,7 @@ namespace ExcelDna.AddIn.Tasks
                 {"OutputPackedXllFileName", outputPackedXllFileName},
                 {"OutputXllConfigFileName", outputXllConfigFileName },
                 {"OutputBitness", outputBitness },
+                {"DocPath", GetDocPath() },
             };
 
             _dnaFilesToPack.Add(new TaskItem(outputDnaFileName, metadata));
@@ -478,7 +486,7 @@ namespace ExcelDna.AddIn.Tasks
                 return;
 
             List<string> filesToPublish = new List<string>();
-            int result = PackedResources.ExcelDnaPack.Pack(dnaPath, null, false, false, false, null, filesToPublish, false, false, null, false, null, _log);
+            int result = PackedResources.ExcelDnaPack.Pack(dnaPath, null, false, false, false, null, filesToPublish, false, false, null, false, null, null, _log);
             if (result != 0)
                 throw new ApplicationException($"Pack failed with exit code {result}.");
             foreach (string file in filesToPublish)

--- a/Source/ExcelDna.AddIn.Tasks/PackExcelAddIn.cs
+++ b/Source/ExcelDna.AddIn.Tasks/PackExcelAddIn.cs
@@ -35,7 +35,7 @@ namespace ExcelDna.AddIn.Tasks
                 useManagedResourceResolver = PackManagedOnWindows || !OperatingSystem.IsWindows();
 #endif
 
-                int result = ExcelDna.PackedResources.ExcelDnaPack.Pack(OutputDnaFileName, OutputPackedXllFileName, CompressResources, RunMultithreaded, true, null, null, PackNativeLibraryDependencies, PackManagedDependencies, ExcludeDependencies, useManagedResourceResolver, OutputBitness, _log);
+                int result = ExcelDna.PackedResources.ExcelDnaPack.Pack(OutputDnaFileName, OutputPackedXllFileName, CompressResources, RunMultithreaded, true, null, null, PackNativeLibraryDependencies, PackManagedDependencies, ExcludeDependencies, useManagedResourceResolver, OutputBitness, DocPath, _log);
                 if (result != 0)
                     throw new ApplicationException($"Pack failed with exit code {result}.");
 
@@ -130,6 +130,11 @@ namespace ExcelDna.AddIn.Tasks
         /// Enable/disable cross-platform resource packing implementation when executing on Windows.
         /// </summary>
         public bool PackManagedOnWindows { get; set; }
+
+        /// <summary>
+        /// .chm help file path
+        /// </summary>
+        public string DocPath { get; set; }
 
         /// <summary>
         /// Path to signtool.exe

--- a/Source/ExcelDna.Loader/DocUtil.cs
+++ b/Source/ExcelDna.Loader/DocUtil.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+
+namespace ExcelDna.Loader
+{
+    internal static class DocUtil
+    {
+        static string LoaderTempDir = Path.Combine(Path.GetTempPath(), "ExcelDna.Loader", Guid.NewGuid().ToString());
+
+        public static string FixHelpTopic(string helpTopic)
+        {
+            string result = helpTopic;
+
+            // Make HelpTopic without full path relative to xllPath
+            if (string.IsNullOrEmpty(helpTopic))
+            {
+                return result;
+            }
+
+            // If http url does not end with !0 it is appended.
+            // I don't think https is supported, but it should not be considered an 'unrooted' path anyway.
+            // I could not get file:/// working (only checked with Excel 2013)
+            if (helpTopic.StartsWith("http://") || helpTopic.StartsWith("https://") || helpTopic.StartsWith("file://"))
+            {
+                if (!helpTopic.EndsWith("!0"))
+                {
+                    result = helpTopic + "!0";
+                }
+            }
+            else if (!Path.IsPathRooted(helpTopic))
+            {
+                result = TryFixUnpacked(helpTopic);
+                if (!Path.IsPathRooted(result))
+                    result = TryFixPacked(result);
+            }
+
+            return result;
+        }
+
+        public static void Clear()
+        {
+            try
+            {
+                Directory.Delete(LoaderTempDir, true);
+            }
+            catch
+            {
+            }
+        }
+
+        private static string TryFixUnpacked(string helpTopic)
+        {
+            string dir = Path.GetDirectoryName(XlAddIn.PathXll);
+            if (File.Exists(Path.Combine(dir, GetFileName(helpTopic))))
+                return Path.Combine(dir, helpTopic);
+
+            return helpTopic;
+        }
+
+        private static string TryFixPacked(string helpTopic)
+        {
+            Directory.CreateDirectory(LoaderTempDir);
+
+            string fileName = GetFileName(helpTopic);
+            byte[] data = XlAddIn.GetResourceBytes(fileName, 6);
+            string filePath = Path.Combine(LoaderTempDir, fileName);
+            File.WriteAllBytes(filePath, data);
+
+            if (File.Exists(filePath))
+                return Path.Combine(LoaderTempDir, helpTopic);
+
+            return helpTopic;
+        }
+
+        private static string GetFileName(string helpTopic)
+        {
+            return helpTopic.Split('!').First();
+        }
+    }
+}

--- a/Source/ExcelDna.Loader/DocUtil.cs
+++ b/Source/ExcelDna.Loader/DocUtil.cs
@@ -6,7 +6,7 @@ namespace ExcelDna.Loader
 {
     internal static class DocUtil
     {
-        static string LoaderTempDir = Path.Combine(Path.GetTempPath(), "ExcelDna.Loader", Guid.NewGuid().ToString());
+        static string tempDocDir;
 
         public static string FixHelpTopic(string helpTopic)
         {
@@ -42,7 +42,8 @@ namespace ExcelDna.Loader
         {
             try
             {
-                Directory.Delete(LoaderTempDir, true);
+                if (tempDocDir != null)
+                    Directory.Delete(tempDocDir, true);
             }
             catch
             {
@@ -60,15 +61,18 @@ namespace ExcelDna.Loader
 
         private static string TryFixPacked(string helpTopic)
         {
-            Directory.CreateDirectory(LoaderTempDir);
+            if (tempDocDir == null)
+                tempDocDir = Path.Combine(XlAddIn.TempDirPath, Guid.NewGuid().ToString());
+
+            Directory.CreateDirectory(tempDocDir);
 
             string fileName = GetFileName(helpTopic);
             byte[] data = XlAddIn.GetResourceBytes(fileName, 6);
-            string filePath = Path.Combine(LoaderTempDir, fileName);
+            string filePath = Path.Combine(tempDocDir, fileName);
             File.WriteAllBytes(filePath, data);
 
             if (File.Exists(filePath))
-                return Path.Combine(LoaderTempDir, helpTopic);
+                return Path.Combine(tempDocDir, helpTopic);
 
             return helpTopic;
         }

--- a/Source/ExcelDna.Loader/DocUtil.cs
+++ b/Source/ExcelDna.Loader/DocUtil.cs
@@ -67,9 +67,14 @@ namespace ExcelDna.Loader
             Directory.CreateDirectory(tempDocDir);
 
             string fileName = GetFileName(helpTopic);
-            byte[] data = XlAddIn.GetResourceBytes(fileName, 6);
             string filePath = Path.Combine(tempDocDir, fileName);
-            File.WriteAllBytes(filePath, data);
+
+            if (!File.Exists(filePath))
+            {
+                byte[] data = XlAddIn.GetResourceBytes(fileName, 6);
+                if (data != null)
+                    File.WriteAllBytes(filePath, data);
+            }
 
             if (File.Exists(filePath))
                 return Path.Combine(tempDocDir, helpTopic);

--- a/Source/ExcelDna.Loader/XlAddIn.cs
+++ b/Source/ExcelDna.Loader/XlAddIn.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -59,6 +60,7 @@ namespace ExcelDna.Loader
 
         // Consider: When does this become an interface. etc
         internal static string PathXll { get; private set; }
+        internal static string TempDirPath { get; private set; }
         internal static Func<string, int, byte[]> GetResourceBytes;  // Passed in from Loader
         internal static Func<string, Assembly> LoadAssemblyFromPath;  // Passed in from Loader
         internal static Func<byte[], byte[], Assembly> LoadAssemblyFromBytes;  // Passed in from Loader
@@ -77,7 +79,7 @@ namespace ExcelDna.Loader
 
         #region Initialization
 
-        public static bool Initialize(IntPtr xlAddInExportInfoAddress, IntPtr hModuleXll, string pathXll,
+        public static bool Initialize(IntPtr xlAddInExportInfoAddress, IntPtr hModuleXll, string pathXll, string tempDirPath,
                                              Func<string, int, byte[]> getResourceBytes,
                                              Func<string, Assembly> loadAssemblyFromPath,
                                              Func<byte[], byte[], Assembly> loadAssemblyFromBytes,
@@ -85,6 +87,7 @@ namespace ExcelDna.Loader
         {
             XlAddIn.hModuleXll = hModuleXll;
             XlAddIn.PathXll = pathXll;
+            XlAddIn.TempDirPath = Path.Combine(tempDirPath ?? Path.GetTempPath(), "ExcelDna.Loader");
             XlAddIn.GetResourceBytes = getResourceBytes;
             XlAddIn.LoadAssemblyFromPath = loadAssemblyFromPath;
             XlAddIn.LoadAssemblyFromBytes = loadAssemblyFromBytes;

--- a/Source/ExcelDna.Loader/XlMethodInfo.cs
+++ b/Source/ExcelDna.Loader/XlMethodInfo.cs
@@ -94,7 +94,7 @@ namespace ExcelDna.Loader
             // We shortcut the rest of the registration
             if (ExplicitRegistration) return;
 
-            FixHelpTopic();
+            HelpTopic = DocUtil.FixHelpTopic(HelpTopic);
 
             // Return type conversion
             // Careful here - native async functions also return void
@@ -146,12 +146,12 @@ namespace ExcelDna.Loader
         }
 
         // Native async functions have a final parameter that is an ExcelAsyncHandle.
-        public bool IsExcelAsyncFunction 
-        { 
-            get 
-            { 
-                return Parameters.Length > 0 && Parameters[Parameters.Length - 1].IsExcelAsyncHandle; 
-            } 
+        public bool IsExcelAsyncFunction
+        {
+            get
+            {
+                return Parameters.Length > 0 && Parameters[Parameters.Length - 1].IsExcelAsyncHandle;
+            }
         }
 
         // Basic setup - get description, category etc.
@@ -205,7 +205,7 @@ namespace ExcelDna.Loader
                     MenuName = cmd.MenuName;
                 if (cmd.MenuText != null)
                     MenuText = cmd.MenuText;
-//                    IsHidden = isHidden;  // Only for functions.
+                //                    IsHidden = isHidden;  // Only for functions.
                 IsExceptionSafe = cmd.IsExceptionSafe;
                 ExplicitRegistration = cmd.ExplicitRegistration;
                 SuppressOverwriteError = cmd.SuppressOverwriteError;
@@ -213,31 +213,7 @@ namespace ExcelDna.Loader
                 // Override IsCommand, even though this 'macro' might have a return value.
                 // Allow for more flexibility in what kind of macros are supported, particularly for calling
                 // via Application.Run.
-                IsCommand = true;   
-            }
-        }
-
-        void FixHelpTopic()
-        {
-            // Make HelpTopic without full path relative to xllPath
-            if (string.IsNullOrEmpty(HelpTopic))
-            {
-                return;
-            }
-           // DOCUMENT: If HelpTopic is not rooted - it is expanded relative to .xll path.
-            // If http url does not end with !0 it is appended.
-            // I don't think https is supported, but it should not be considered an 'unrooted' path anyway.
-            // I could not get file:/// working (only checked with Excel 2013)
-            if (HelpTopic.StartsWith("http://") || HelpTopic.StartsWith("https://") || HelpTopic.StartsWith("file://"))
-            {
-                if (!HelpTopic.EndsWith("!0"))
-                {
-                    HelpTopic = HelpTopic + "!0";
-                }
-            }
-            else if (!Path.IsPathRooted(HelpTopic))
-            {
-                HelpTopic = Path.Combine(Path.GetDirectoryName(XlAddIn.PathXll), HelpTopic);
+                IsCommand = true;
             }
         }
 
@@ -334,7 +310,7 @@ namespace ExcelDna.Loader
     }
 
     internal static class TypeHelper
-    {   
+    {
         internal static bool TypeHasAncestorWithFullName(Type type, string fullName)
         {
             if (type == null) return false;
@@ -343,12 +319,12 @@ namespace ExcelDna.Loader
         }
     }
 
-	// TODO: improve information about the problem
-	internal class DnaMarshalException : Exception
-	{
-		public DnaMarshalException(string message) :
-			base(message)
-		{
-		}
-	}
+    // TODO: improve information about the problem
+    internal class DnaMarshalException : Exception
+    {
+        public DnaMarshalException(string message) :
+            base(message)
+        {
+        }
+    }
 }

--- a/Source/ExcelDna.ManagedHost/AddInInitialize.cs
+++ b/Source/ExcelDna.ManagedHost/AddInInitialize.cs
@@ -47,7 +47,7 @@ namespace ExcelDna.ManagedHost
             var loaderAssembly = _alc.LoadFromAssemblyName(new AssemblyName("ExcelDna.Loader"));
             var xlAddInType = loaderAssembly.GetType("ExcelDna.Loader.XlAddIn");
             var initOK = (bool)xlAddInType.InvokeMember("Initialize", BindingFlags.Public | BindingFlags.Static | BindingFlags.InvokeMethod, null, null,
-                new object[] { (IntPtr)xlAddInExportInfoAddress, (IntPtr)hModuleXll, pathXll,
+                new object[] { (IntPtr)xlAddInExportInfoAddress, (IntPtr)hModuleXll, pathXll, tempDirPath,
                     (Func<string, int, byte[]>)AssemblyManager.GetResourceBytes,
                     (Func<string, Assembly>)_alc.LoadFromAssemblyPath,
                     (Func<byte[], byte[], Assembly>)_alc.LoadFromAssemblyBytes,
@@ -106,7 +106,7 @@ namespace ExcelDna.ManagedHost
                 Func<byte[], byte[], Assembly> loadFromAssemblyBytes,
                 Action<TraceSource> setIntegrationTraceSource)
         {
-            return XlAddIn.Initialize(xlAddInExportInfoAddress, hModuleXll, pathXll, getResourceBytes, loadFromAssemblyPath, loadFromAssemblyBytes, setIntegrationTraceSource);
+            return XlAddIn.Initialize(xlAddInExportInfoAddress, hModuleXll, pathXll, null, getResourceBytes, loadFromAssemblyPath, loadFromAssemblyBytes, setIntegrationTraceSource);
         }
     }
 #endif

--- a/Source/ExcelDna.ManagedHost/AssemblyManager.cs
+++ b/Source/ExcelDna.ManagedHost/AssemblyManager.cs
@@ -204,6 +204,10 @@ namespace ExcelDna.ManagedHost
             {
                 typeName = "NATIVE_LIBRARY";
             }
+            else if (type == 6)
+            {
+                typeName = "DOC";
+            }
             else
             {
                 throw new ArgumentOutOfRangeException("type", "Unknown resource type.");

--- a/Source/ExcelDna.PackedResources/ExcelDnaPack.cs
+++ b/Source/ExcelDna.PackedResources/ExcelDnaPack.cs
@@ -10,7 +10,7 @@ namespace ExcelDna.PackedResources
 {
     internal class ExcelDnaPack
     {
-        public static int Pack(string dnaPath, string xllOutputPathParam, bool compress, bool multithreading, bool overwrite, string usageInfo, List<string> filesToPublish, bool packNativeLibraryDependencies, bool packManagedDependencies, string excludeDependencies, bool useManagedResourceResolver, string outputBitness, IBuildLogger buildLogger)
+        public static int Pack(string dnaPath, string xllOutputPathParam, bool compress, bool multithreading, bool overwrite, string usageInfo, List<string> filesToPublish, bool packNativeLibraryDependencies, bool packManagedDependencies, string excludeDependencies, bool useManagedResourceResolver, string outputBitness, string docPath, IBuildLogger buildLogger)
         {
             string HostXLL = outputBitness == "64" ? "ExcelDna64.xll" : "ExcelDna.xll";
             string dnaDirectory = Path.GetDirectoryName(dnaPath);
@@ -125,6 +125,11 @@ namespace ExcelDna.PackedResources
 
                     ru.AddFile(File.ReadAllBytes(nativeLibrary), Path.GetFileName(nativeLibrary).ToUpperInvariant(), ResourceHelper.TypeName.NATIVE_LIBRARY, "Native deps.json", compress, multithreading);
                 }
+            }
+
+            if (!string.IsNullOrWhiteSpace(docPath) && filesToPublish == null)
+            {
+                ru.AddFile(File.ReadAllBytes(docPath), Path.GetFileName(docPath).ToUpperInvariant(), ResourceHelper.TypeName.DOC, null, compress, multithreading);
             }
 
             byte[] dnaBytes = File.ReadAllBytes(dnaPath);

--- a/Source/ExcelDna.PackedResources/ResourceHelper.cs
+++ b/Source/ExcelDna.PackedResources/ResourceHelper.cs
@@ -25,6 +25,7 @@ internal static class ResourceHelper
         SOURCE = 3,
         PDB = 4,
         NATIVE_LIBRARY = 5,
+        DOC = 6,
     }
 
     // TODO: Learn about locales

--- a/Source/ExcelDnaPack/PackProgram.cs
+++ b/Source/ExcelDnaPack/PackProgram.cs
@@ -133,7 +133,7 @@ Other assemblies are packed if marked with Pack=""true"" in the .dna file.
                 }
             }
 
-            int result = ExcelDna.PackedResources.ExcelDnaPack.Pack(dnaPath, xllOutputPath, compress, multithreading, overwrite, usageInfo, null, false, false, null, false, outputBitness, buildLogger);
+            int result = ExcelDna.PackedResources.ExcelDnaPack.Pack(dnaPath, xllOutputPath, compress, multithreading, overwrite, usageInfo, null, false, false, null, false, outputBitness, null, buildLogger);
 
 #if DEBUG
             if (result == 0)

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget.sln
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget.sln
@@ -126,6 +126,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NET6Channels", "NET6Channel
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NET6LoadFromBytes", "NET6LoadFromBytes\NET6LoadFromBytes.csproj", "{2AB7042E-E54F-4EFD-A5B7-5D1BAE005D17}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SDKPackDoc", "SDKPackDoc\SDKPackDoc.csproj", "{9429E0A9-E9B1-4DF5-95C1-8E7AE2AA41FF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -376,6 +378,10 @@ Global
 		{2AB7042E-E54F-4EFD-A5B7-5D1BAE005D17}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2AB7042E-E54F-4EFD-A5B7-5D1BAE005D17}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2AB7042E-E54F-4EFD-A5B7-5D1BAE005D17}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9429E0A9-E9B1-4DF5-95C1-8E7AE2AA41FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9429E0A9-E9B1-4DF5-95C1-8E7AE2AA41FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9429E0A9-E9B1-4DF5-95C1-8E7AE2AA41FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9429E0A9-E9B1-4DF5-95C1-8E7AE2AA41FF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SDKPackDoc/Functions.cs
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SDKPackDoc/Functions.cs
@@ -13,5 +13,15 @@ namespace SDKPackDoc
         {
             return string.Concat(a.ToString(), b.ToString());
         }
+
+        [ExcelFunction(Name = "Text.ConcatThemCustom",
+                Description = "concatenates two strings (with custom help file name)",
+                HelpTopic = "MyCustomFileName.chm!1003")]
+        public static object ConcatThemCustom(
+    [ExcelArgument(Description = "the first string")] object a,
+    [ExcelArgument(Description = "the second string")] object b)
+        {
+            return string.Concat(a.ToString(), b.ToString());
+        }
     }
 }

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SDKPackDoc/Functions.cs
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SDKPackDoc/Functions.cs
@@ -1,0 +1,17 @@
+﻿using ExcelDna.Integration;
+
+namespace SDKPackDoc
+{
+    public class Text
+    {
+        [ExcelFunction(Name = "Text.ConcatThem",
+                        Description = "concatenates two strings",
+                        HelpTopic = "SDKPackDoc-AddIn.chm!1002")]
+        public static object ConcatThem(
+            [ExcelArgument(Description = "the first string")] object a,
+            [ExcelArgument(Description = "the second string")] object b)
+        {
+            return string.Concat(a.ToString(), b.ToString());
+        }
+    }
+}

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SDKPackDoc/SDKPackDoc.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SDKPackDoc/SDKPackDoc.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <UseWindowsForms>True</UseWindowsForms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ExcelDnaDoc" Version="1.8.0" />
+  </ItemGroup>
+
+  <Import Project="$(ProjectDir)..\..\.exceldna.addin\build\ExcelDna.AddIn.targets" />
+
+</Project>

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SDKPackDoc/SDKPackDoc.csproj
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests.TestTarget/SDKPackDoc/SDKPackDoc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
     <UseWindowsForms>True</UseWindowsForms>
   </PropertyGroup>
 

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests/SDKPackDocTests.cs
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests/SDKPackDocTests.cs
@@ -1,0 +1,36 @@
+﻿using NUnit.Framework;
+
+namespace ExcelDna.AddIn.Tasks.IntegrationTests
+{
+    [TestFixture]
+    public class SDKPackDocTests : IntegrationTestBase
+    {
+        [Test]
+        public void Pack()
+        {
+            const string projectBasePath = @"SDKPackDoc\";
+            const string projectOutDir = projectBasePath + @"bin\Release\";
+            const string publishDir = projectOutDir + @"publish\";
+
+            Clean(projectOutDir);
+
+            // The first build on a clean project doesn't create .chm at all, but the second run creates .chm and publishes it: 
+            for (int i = 0; i < 2; ++i)
+                MsBuild(projectBasePath + "SDKPackDoc.csproj /t:Restore,Build /p:Configuration=Release /v:m " + MsBuildParam("OutputPath", @"bin\Release\"));
+        }
+
+        [Test]
+        public void CustomFileName()
+        {
+            const string projectBasePath = @"SDKPackDoc\";
+            const string projectOutDir = projectBasePath + @"bin\ReleaseCustomFileName\";
+            const string publishDir = projectOutDir + @"publish\";
+
+            Clean(projectOutDir);
+
+            // The first build on a clean project doesn't create .chm at all, but the second run creates .chm and publishes it: 
+            for (int i = 0; i < 2; ++i)
+                MsBuild(projectBasePath + "SDKPackDoc.csproj /p:ExcelAddInFileName=MyCustomFileName /t:Restore,Build /p:Configuration=Release /v:m " + MsBuildParam("OutputPath", @"bin\ReleaseCustomFileName\"));
+        }
+    }
+}

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests/SDKPublishDocTests.cs
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests/SDKPublishDocTests.cs
@@ -21,5 +21,21 @@ namespace ExcelDna.AddIn.Tasks.IntegrationTests
 
             AssertNotFound(Path.Combine(publishDir, "SDKPublishDoc-AddIn.chm"));
         }
+
+        [Test]
+        public void UnPacked()
+        {
+            const string projectBasePath = @"SDKPublishDoc\";
+            const string projectOutDir = projectBasePath + @"bin\Release\";
+            const string publishDir = projectOutDir + @"publish\";
+
+            Clean(projectOutDir);
+
+            // The first build on a clean project doesn't create .chm at all, but the second run creates .chm and publishes it: 
+            for (int i = 0; i < 2; ++i)
+                MsBuild(projectBasePath + "SDKPublishDoc.csproj /p:ExcelDnaUnpack=true /t:Restore,Build /p:Configuration=Release /v:m " + MsBuildParam("OutputPath", @"bin\Release\"));
+
+            AssertOutput(publishDir, "*.chm", "SDKPublishDoc-AddIn.chm");
+        }
     }
 }

--- a/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests/SDKPublishDocTests.cs
+++ b/Source/Tests/ExcelDna.AddIn.Tasks.IntegrationTests/SDKPublishDocTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using System.IO;
 
 namespace ExcelDna.AddIn.Tasks.IntegrationTests
 {
@@ -18,7 +19,7 @@ namespace ExcelDna.AddIn.Tasks.IntegrationTests
             for (int i = 0; i < 2; ++i)
                 MsBuild(projectBasePath + "SDKPublishDoc.csproj /t:Restore,Build /p:Configuration=Release /v:m " + MsBuildParam("OutputPath", @"bin\Release\"));
 
-            AssertOutput(publishDir, "*.chm", "SDKPublishDoc-AddIn.chm");
+            AssertNotFound(Path.Combine(publishDir, "SDKPublishDoc-AddIn.chm"));
         }
     }
 }

--- a/Source/Tests/ExcelDna.PackedResourcesTests/ExcelDnaPackTests.cs
+++ b/Source/Tests/ExcelDna.PackedResourcesTests/ExcelDnaPackTests.cs
@@ -17,7 +17,7 @@ namespace ExcelDna.PackedResourcesTests
             string xllFile = TestdataHelper.FilePath("test_pack-AddIn.xll");
             string outPath = TestdataHelper.FilePath("ExcelDnaPackTests-AddIn64-packed-out.dll");
             File.Copy(TestdataHelper.FilePath("AddIn64-compressed.dll"), xllFile, true);
-            ExcelDnaPack.Pack(dnaFile, outPath, true, false, true, null, null, false, false, null, useManagedResourceResolver, null, A.Dummy<IBuildLogger>());
+            ExcelDnaPack.Pack(dnaFile, outPath, true, false, true, null, null, false, false, null, useManagedResourceResolver, null, null, A.Dummy<IBuildLogger>());
 
             Assert.That(File.ReadAllBytes(outPath), Is.EqualTo(File.ReadAllBytes(TestdataHelper.FilePath(useManagedResourceResolver ? "AddIn64-packedX-compressed.dll" : "AddIn64-packed-compressed.dll"))));
             File.Delete(outPath);


### PR DESCRIPTION
A .chm help file is now stored as a resource in the published .xll, instead of being copied to the publish folder.

Extraction of a help file to a temp dir and getting the right path into the help topic is implemented in Loader.

For .NET Core add-ins, ExcelDna.Host temp dir is reused for help file extraction on add-in loading. It is automatically deleted on ExcelDna.Host temp dir cleanup.

For .NET Framework add-ins, ExcelDna.Loader temp dir is created for help file extraction. No cleanup occurs. (We don’t have ExcelDna.Host temp dir in this configuration and I could not find an alternative solution.) Can be prevented by manually distributing .chm along with .xll - if a help file is present in the same directory with .xll, it is used directly and no extraction occurs.
