### PR TITLE
Update ExcelDna.AddIn.targets for .net10

### DIFF
--- a/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
+++ b/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
@@ -202,16 +202,11 @@
 		<ExcelDnaTlbDscom Condition="'$(ExcelDnaTlbDscom)' == ''">false</ExcelDnaTlbDscom>
 	</PropertyGroup>
 
-	<!--
-    Updated to use TargetFramework instead of old TargetFrameworkVersion
-			.Net versions: netcoreapp3.1, net6.0, net7.0, etc..
-			or .Net Framework: v4.7.2, v4.8, etc.. 
-  -->
-	<PropertyGroup Condition="'$(TargetFramework.Length())' >= '3' AND '$(TargetFramework.Substring(0,3))' == 'net'">
+	<PropertyGroup Condition="$([System.Version]::Parse('$(TargetFrameworkVersion.Substring(1))').CompareTo($([System.Version]::Parse('6.0')))) >= 0">
 		<ExcelDnaRuntimeToolsPath>$(ExcelDnaToolsPath)\net6.0-windows7.0\</ExcelDnaRuntimeToolsPath>
 		<ExcelDnaTlbDscom>true</ExcelDnaTlbDscom>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(TargetFramework.Length())' >= '3' AND '$(TargetFramework.Substring(0,3))' != 'net'">
+	<PropertyGroup Condition="'$(TargetFrameworkVersion.Length())' >= '2' AND '$(TargetFrameworkVersion.Substring(0,2))' == 'v4'">
 		<ExcelDnaRuntimeToolsPath>$(ExcelDnaToolsPath)\net462\</ExcelDnaRuntimeToolsPath>
 	</PropertyGroup>
 

--- a/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
+++ b/Package/ExcelDna.AddIn/build/ExcelDna.AddIn.targets
@@ -201,12 +201,17 @@
 	<PropertyGroup>
 		<ExcelDnaTlbDscom Condition="'$(ExcelDnaTlbDscom)' == ''">false</ExcelDnaTlbDscom>
 	</PropertyGroup>
-		
-	<PropertyGroup Condition="'$(TargetFrameworkVersion.Length())' >= '2' AND '$(TargetFrameworkVersion.Substring(1,1))' >= '6'">
+
+	<!--
+    Updated to use TargetFramework instead of old TargetFrameworkVersion
+			.Net versions: netcoreapp3.1, net6.0, net7.0, etc..
+			or .Net Framework: v4.7.2, v4.8, etc.. 
+  -->
+	<PropertyGroup Condition="'$(TargetFramework.Length())' >= '3' AND '$(TargetFramework.Substring(0,3))' == 'net'">
 		<ExcelDnaRuntimeToolsPath>$(ExcelDnaToolsPath)\net6.0-windows7.0\</ExcelDnaRuntimeToolsPath>
 		<ExcelDnaTlbDscom>true</ExcelDnaTlbDscom>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(TargetFrameworkVersion.Length())' >= '2' AND '$(TargetFrameworkVersion.Substring(0,2))' == 'v4'">
+	<PropertyGroup Condition="'$(TargetFramework.Length())' >= '3' AND '$(TargetFramework.Substring(0,3))' != 'net'">
 		<ExcelDnaRuntimeToolsPath>$(ExcelDnaToolsPath)\net462\</ExcelDnaRuntimeToolsPath>
 	</PropertyGroup>
 


### PR DESCRIPTION
Currently checks for TargetFrameworkVersion.Substring(1,1) >= 6 which fails with net10.0. Not sure if the test is .net core vs framework or actually requires .net6.0 or higher. Have updated to using TargetFramework instead of TargetFrameworkVersion. Have implemented very simple .Substring(0,3) == 'net' or not.