### PR TITLE
Invoke ProcessStartupHooks with the correct number of arguments

### DIFF
--- a/Source/ExcelDna.ManagedHost/AddInInitialize.cs
+++ b/Source/ExcelDna.ManagedHost/AddInInitialize.cs
@@ -107,7 +107,7 @@ namespace ExcelDna.ManagedHost
             {
                 Type StartupHookProviderType = Type.GetType($"System.StartupHookProvider, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e");
                 MethodInfo ProcessStartupHooksMethod = StartupHookProviderType.GetMethod("ProcessStartupHooks", BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.InvokeMethod);
-                ProcessStartupHooksMethod.Invoke(null, null);
+                ProcessStartupHooksMethod.Invoke(null, new object[] { null });
             }
             catch
             {


### PR DESCRIPTION
Behavior before this change: 
Every time you start the add-in this line appears in the Debug log: `Exception thrown: 'System.Reflection.TargetParameterCountException' in System.Private.CoreLib.dll`

After this change: that line no longer appears in the Debug log.

Rationale for the change:

The method we are invoking is declared `private static void StartupHookProvider.ProcessStartupHooks(string diagnosticStartupHooks)`

However we are invoking it incorrectly:
when we say `.Invoke(null, null)` the first null means invoke a static method, and the second null means "there are no arguments"

It is incorrect to assert no arguments, because there is in fact one argument: `string diagnosticStartupHooks`

I believe what is intended here is to invoke the method with one argument whose value is null.

So the correct invocation is
``` ProcessStartupHooksMethod.Invoke(null, new object[] { null });```

I have tested this change in my own sandbox, but I haven't tested it in the whole ExcelDNA product because I don't know what this feature is supposed to accomplish and what a successful test looks like. But I can say it takes its intended action now rather than 100% failing.