### PR TITLE
Root NativeAOT expression shapes after parameter conversion rewrites

### DIFF
--- a/Source/ExcelDna.Integration/Registration/ExcelFunctionRegistration.cs
+++ b/Source/ExcelDna.Integration/Registration/ExcelFunctionRegistration.cs
@@ -145,6 +145,9 @@ namespace ExcelDna.Registration
             Debug.Assert(IsValid());
         }
 
+#if AOT_COMPATIBLE
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL3050:RequiresDynamicCode", Justification = "SourceGenerator roots required Expression<TDelegate> shapes")]
+#endif
         private static LambdaExpression CreateMethodLambda(MethodInfo methodInfo, IReadOnlyList<ParameterExpression> paramExprs)
         {
             try

--- a/Source/ExcelDna.Integration/Registration/ParameterConversionRegistration.cs
+++ b/Source/ExcelDna.Integration/Registration/ParameterConversionRegistration.cs
@@ -142,6 +142,9 @@ namespace ExcelDna.Registration
             return result;
         }
 
+#if AOT_COMPATIBLE
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL3050:RequiresDynamicCode", Justification = "SourceGenerator roots required Expression<TDelegate> shapes")]
+#endif
         static LambdaExpression CreateLambdaWithAotContext(Expression body, string lambdaName, IEnumerable<ParameterExpression> parameters, string operation)
         {
             try

--- a/Source/ExcelDna.SourceGenerator.NativeAOT/Generator.cs
+++ b/Source/ExcelDna.SourceGenerator.NativeAOT/Generator.cs
@@ -95,6 +95,12 @@ namespace ExcelDna.SourceGenerator.NativeAOT
                     functions += $"{regHost}.MethodsForRegistration.Add({GetMethod(i)});\r\n";
                     functions += $"typeRefs.Add(typeof({Util.MethodType(i)}));\r\n";
                     functions += $"typeRefs.Add(typeof({Util.MethodExpressionType(i)}));\r\n";
+                    if (Util.HasPostParameterConversionShape(i))
+                    {
+                        string convertedMethodType = Util.MethodPostParameterConversionType(i);
+                        functions += $"typeRefs.Add(typeof({convertedMethodType}));\r\n";
+                        functions += $"typeRefs.Add(typeof(System.Linq.Expressions.Expression<{convertedMethodType}>));\r\n";
+                    }
                     foreach (var p in i.Parameters)
                     {
                         functions += $"typeRefs.Add(typeof(Func<object, {Util.GetFullTypeName(p.Type)}>));\r\n";

--- a/Source/Tests/ExcelDna.SourceGenerator.NativeAOT.Tests/Generator.cs
+++ b/Source/Tests/ExcelDna.SourceGenerator.NativeAOT.Tests/Generator.cs
@@ -30,6 +30,8 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
                 ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeParamsJoinString")!);
                 typeRefs.Add(typeof(Func<string, string[], string>));
                 typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<string, string[], string>>));
+                typeRefs.Add(typeof(Func<string, object[], string>));
+                typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<string, object[], string>>));
                 typeRefs.Add(typeof(Func<object, string>));
                 typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<object, string>>));
                 typeRefs.Add(typeof(Func<object, string[]>));
@@ -40,6 +42,43 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
                 List<MethodInfo> methodRefs = new List<MethodInfo>();
                 methodRefs.Add(typeof(List<string>).GetMethod("ToArray")!);
                 methodRefs.Add(typeof(List<string>).GetMethod("Add")!);
+                """);
+        }
+
+        [Fact]
+        public void OptionalParameters()
+        {
+            Verify("""
+                using ExcelDna.Integration;
+
+                namespace ExcelDna.AddIn.RuntimeTestsAOT
+                {
+                    public class Functions
+                    {
+                        [ExcelFunction]
+                        public static string NativeOptional(object refRange, double targetValue, int maxCombinations = 1, bool isCache = true)
+                        {
+                            return "";
+                        }
+                    }
+                }
+                """, functions: """
+                List<Type> typeRefs = new List<Type>();
+                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeOptional")!);
+                typeRefs.Add(typeof(Func<object, double, int, bool, string>));
+                typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<object, double, int, bool, string>>));
+                typeRefs.Add(typeof(Func<object, double, object, object, string>));
+                typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<object, double, object, object, string>>));
+                typeRefs.Add(typeof(Func<object, object>));
+                typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<object, object>>));
+                typeRefs.Add(typeof(Func<object, double>));
+                typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<object, double>>));
+                typeRefs.Add(typeof(Func<object, int>));
+                typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<object, int>>));
+                typeRefs.Add(typeof(Func<object, bool>));
+                typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<object, bool>>));
+                
+                List<MethodInfo> methodRefs = new List<MethodInfo>();
                 """);
         }
 

--- a/Source/Tests/ExcelDna.SourceGenerator.NativeAOT.Tests/SourceGeneratorDriver.cs
+++ b/Source/Tests/ExcelDna.SourceGenerator.NativeAOT.Tests/SourceGeneratorDriver.cs
@@ -36,10 +36,12 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
             Assert.Empty(generatorResult.Diagnostics);
             Assert.True(generatorResult.GeneratedSources.Length == 2);
             Assert.True(generatorResult.Exception is null);
+
+            static string NormalizeLineEndings(string s) => s.Replace("\r\n", "\n");
             if (expected0 != null)
-                Assert.Equal(expected0, generatorResult.GeneratedSources[0].SourceText.ToString());
+                Assert.Equal(NormalizeLineEndings(expected0), NormalizeLineEndings(generatorResult.GeneratedSources[0].SourceText.ToString()));
             if (expected1 != null)
-                Assert.Equal(expected1, generatorResult.GeneratedSources[1].SourceText.ToString());
+                Assert.Equal(NormalizeLineEndings(expected1), NormalizeLineEndings(generatorResult.GeneratedSources[1].SourceText.ToString()));
         }
     }
 }


### PR DESCRIPTION
*Posted by Codex agent on behalf of @govert*

## Summary
This PR fixes a NativeAOT registration failure where ParameterConversionRegistration.ApplyConversions rebuilds a lambda with a delegate signature that differs from the original method signature (for example optional/default parameters rewritten to object inputs).

## Problem
Under NativeAOT, Expression.Lambda(...) requires rooted metadata for the exact Expression<Func<...>> shape being created. We rooted original method shapes, but not the post-conversion shapes produced during registration rewriting, causing runtime initialization failures.

## Changes
- Root post-parameter-conversion delegate/expression shapes in ExcelDna.SourceGenerator.NativeAOT.
- Add a generator test for optional-parameter shape rooting and update params test expectations.
- Normalize line endings in source-generator expected/actual comparison to avoid CRLF/LF test fragility.
- Add targeted IL3050 suppressions on the two guarded helper methods where expression creation is intentionally used with source-generated rooting.

## Validation
- dotnet test Source/Tests/ExcelDna.SourceGenerator.NativeAOT.Tests/ExcelDna.SourceGenerator.NativeAOT.Tests.csproj -c Release (pass)

## Similar-case pass notes
I also reviewed nearby expression-building sites (async wrappers, params wrappers, execution handlers, object-handle flows). This PR is focused on the ApplyConversions shape gap that reproduces the current failure.
