### PR TITLE
add NAOT support for excel functions w 16-29 arguments

### DIFF
--- a/Source/ExcelDna.Integration/Registration/AotExtendedFunc.cs
+++ b/Source/ExcelDna.Integration/Registration/AotExtendedFunc.cs
@@ -1,0 +1,815 @@
+using System;
+
+namespace ExcelDna.Registration
+{
+    public delegate TResult AotFunc17<
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+        T16,
+        T17,
+        TResult
+    >(
+        T1 arg1,
+        T2 arg2,
+        T3 arg3,
+        T4 arg4,
+        T5 arg5,
+        T6 arg6,
+        T7 arg7,
+        T8 arg8,
+        T9 arg9,
+        T10 arg10,
+        T11 arg11,
+        T12 arg12,
+        T13 arg13,
+        T14 arg14,
+        T15 arg15,
+        T16 arg16,
+        T17 arg17
+    );
+
+    public delegate TResult AotFunc18<
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+        T16,
+        T17,
+        T18,
+        TResult
+    >(
+        T1 arg1,
+        T2 arg2,
+        T3 arg3,
+        T4 arg4,
+        T5 arg5,
+        T6 arg6,
+        T7 arg7,
+        T8 arg8,
+        T9 arg9,
+        T10 arg10,
+        T11 arg11,
+        T12 arg12,
+        T13 arg13,
+        T14 arg14,
+        T15 arg15,
+        T16 arg16,
+        T17 arg17,
+        T18 arg18
+    );
+
+    public delegate TResult AotFunc19<
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+        T16,
+        T17,
+        T18,
+        T19,
+        TResult
+    >(
+        T1 arg1,
+        T2 arg2,
+        T3 arg3,
+        T4 arg4,
+        T5 arg5,
+        T6 arg6,
+        T7 arg7,
+        T8 arg8,
+        T9 arg9,
+        T10 arg10,
+        T11 arg11,
+        T12 arg12,
+        T13 arg13,
+        T14 arg14,
+        T15 arg15,
+        T16 arg16,
+        T17 arg17,
+        T18 arg18,
+        T19 arg19
+    );
+
+    public delegate TResult AotFunc20<
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+        T16,
+        T17,
+        T18,
+        T19,
+        T20,
+        TResult
+    >(
+        T1 arg1,
+        T2 arg2,
+        T3 arg3,
+        T4 arg4,
+        T5 arg5,
+        T6 arg6,
+        T7 arg7,
+        T8 arg8,
+        T9 arg9,
+        T10 arg10,
+        T11 arg11,
+        T12 arg12,
+        T13 arg13,
+        T14 arg14,
+        T15 arg15,
+        T16 arg16,
+        T17 arg17,
+        T18 arg18,
+        T19 arg19,
+        T20 arg20
+    );
+
+    public delegate TResult AotFunc21<
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+        T16,
+        T17,
+        T18,
+        T19,
+        T20,
+        T21,
+        TResult
+    >(
+        T1 arg1,
+        T2 arg2,
+        T3 arg3,
+        T4 arg4,
+        T5 arg5,
+        T6 arg6,
+        T7 arg7,
+        T8 arg8,
+        T9 arg9,
+        T10 arg10,
+        T11 arg11,
+        T12 arg12,
+        T13 arg13,
+        T14 arg14,
+        T15 arg15,
+        T16 arg16,
+        T17 arg17,
+        T18 arg18,
+        T19 arg19,
+        T20 arg20,
+        T21 arg21
+    );
+
+    public delegate TResult AotFunc22<
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+        T16,
+        T17,
+        T18,
+        T19,
+        T20,
+        T21,
+        T22,
+        TResult
+    >(
+        T1 arg1,
+        T2 arg2,
+        T3 arg3,
+        T4 arg4,
+        T5 arg5,
+        T6 arg6,
+        T7 arg7,
+        T8 arg8,
+        T9 arg9,
+        T10 arg10,
+        T11 arg11,
+        T12 arg12,
+        T13 arg13,
+        T14 arg14,
+        T15 arg15,
+        T16 arg16,
+        T17 arg17,
+        T18 arg18,
+        T19 arg19,
+        T20 arg20,
+        T21 arg21,
+        T22 arg22
+    );
+
+    public delegate TResult AotFunc23<
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+        T16,
+        T17,
+        T18,
+        T19,
+        T20,
+        T21,
+        T22,
+        T23,
+        TResult
+    >(
+        T1 arg1,
+        T2 arg2,
+        T3 arg3,
+        T4 arg4,
+        T5 arg5,
+        T6 arg6,
+        T7 arg7,
+        T8 arg8,
+        T9 arg9,
+        T10 arg10,
+        T11 arg11,
+        T12 arg12,
+        T13 arg13,
+        T14 arg14,
+        T15 arg15,
+        T16 arg16,
+        T17 arg17,
+        T18 arg18,
+        T19 arg19,
+        T20 arg20,
+        T21 arg21,
+        T22 arg22,
+        T23 arg23
+    );
+
+    public delegate TResult AotFunc24<
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+        T16,
+        T17,
+        T18,
+        T19,
+        T20,
+        T21,
+        T22,
+        T23,
+        T24,
+        TResult
+    >(
+        T1 arg1,
+        T2 arg2,
+        T3 arg3,
+        T4 arg4,
+        T5 arg5,
+        T6 arg6,
+        T7 arg7,
+        T8 arg8,
+        T9 arg9,
+        T10 arg10,
+        T11 arg11,
+        T12 arg12,
+        T13 arg13,
+        T14 arg14,
+        T15 arg15,
+        T16 arg16,
+        T17 arg17,
+        T18 arg18,
+        T19 arg19,
+        T20 arg20,
+        T21 arg21,
+        T22 arg22,
+        T23 arg23,
+        T24 arg24
+    );
+
+    public delegate TResult AotFunc25<
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+        T16,
+        T17,
+        T18,
+        T19,
+        T20,
+        T21,
+        T22,
+        T23,
+        T24,
+        T25,
+        TResult
+    >(
+        T1 arg1,
+        T2 arg2,
+        T3 arg3,
+        T4 arg4,
+        T5 arg5,
+        T6 arg6,
+        T7 arg7,
+        T8 arg8,
+        T9 arg9,
+        T10 arg10,
+        T11 arg11,
+        T12 arg12,
+        T13 arg13,
+        T14 arg14,
+        T15 arg15,
+        T16 arg16,
+        T17 arg17,
+        T18 arg18,
+        T19 arg19,
+        T20 arg20,
+        T21 arg21,
+        T22 arg22,
+        T23 arg23,
+        T24 arg24,
+        T25 arg25
+    );
+
+    public delegate TResult AotFunc26<
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+        T16,
+        T17,
+        T18,
+        T19,
+        T20,
+        T21,
+        T22,
+        T23,
+        T24,
+        T25,
+        T26,
+        TResult
+    >(
+        T1 arg1,
+        T2 arg2,
+        T3 arg3,
+        T4 arg4,
+        T5 arg5,
+        T6 arg6,
+        T7 arg7,
+        T8 arg8,
+        T9 arg9,
+        T10 arg10,
+        T11 arg11,
+        T12 arg12,
+        T13 arg13,
+        T14 arg14,
+        T15 arg15,
+        T16 arg16,
+        T17 arg17,
+        T18 arg18,
+        T19 arg19,
+        T20 arg20,
+        T21 arg21,
+        T22 arg22,
+        T23 arg23,
+        T24 arg24,
+        T25 arg25,
+        T26 arg26
+    );
+
+    public delegate TResult AotFunc27<
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+        T16,
+        T17,
+        T18,
+        T19,
+        T20,
+        T21,
+        T22,
+        T23,
+        T24,
+        T25,
+        T26,
+        T27,
+        TResult
+    >(
+        T1 arg1,
+        T2 arg2,
+        T3 arg3,
+        T4 arg4,
+        T5 arg5,
+        T6 arg6,
+        T7 arg7,
+        T8 arg8,
+        T9 arg9,
+        T10 arg10,
+        T11 arg11,
+        T12 arg12,
+        T13 arg13,
+        T14 arg14,
+        T15 arg15,
+        T16 arg16,
+        T17 arg17,
+        T18 arg18,
+        T19 arg19,
+        T20 arg20,
+        T21 arg21,
+        T22 arg22,
+        T23 arg23,
+        T24 arg24,
+        T25 arg25,
+        T26 arg26,
+        T27 arg27
+    );
+
+    public delegate TResult AotFunc28<
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+        T16,
+        T17,
+        T18,
+        T19,
+        T20,
+        T21,
+        T22,
+        T23,
+        T24,
+        T25,
+        T26,
+        T27,
+        T28,
+        TResult
+    >(
+        T1 arg1,
+        T2 arg2,
+        T3 arg3,
+        T4 arg4,
+        T5 arg5,
+        T6 arg6,
+        T7 arg7,
+        T8 arg8,
+        T9 arg9,
+        T10 arg10,
+        T11 arg11,
+        T12 arg12,
+        T13 arg13,
+        T14 arg14,
+        T15 arg15,
+        T16 arg16,
+        T17 arg17,
+        T18 arg18,
+        T19 arg19,
+        T20 arg20,
+        T21 arg21,
+        T22 arg22,
+        T23 arg23,
+        T24 arg24,
+        T25 arg25,
+        T26 arg26,
+        T27 arg27,
+        T28 arg28
+    );
+
+    public delegate TResult AotFunc29<
+        T1,
+        T2,
+        T3,
+        T4,
+        T5,
+        T6,
+        T7,
+        T8,
+        T9,
+        T10,
+        T11,
+        T12,
+        T13,
+        T14,
+        T15,
+        T16,
+        T17,
+        T18,
+        T19,
+        T20,
+        T21,
+        T22,
+        T23,
+        T24,
+        T25,
+        T26,
+        T27,
+        T28,
+        T29,
+        TResult
+    >(
+        T1 arg1,
+        T2 arg2,
+        T3 arg3,
+        T4 arg4,
+        T5 arg5,
+        T6 arg6,
+        T7 arg7,
+        T8 arg8,
+        T9 arg9,
+        T10 arg10,
+        T11 arg11,
+        T12 arg12,
+        T13 arg13,
+        T14 arg14,
+        T15 arg15,
+        T16 arg16,
+        T17 arg17,
+        T18 arg18,
+        T19 arg19,
+        T20 arg20,
+        T21 arg21,
+        T22 arg22,
+        T23 arg23,
+        T24 arg24,
+        T25 arg25,
+        T26 arg26,
+        T27 arg27,
+        T28 arg28,
+        T29 arg29
+    );
+
+    // Utility class to get the appropriate delegate type
+    internal class AotExtendedFuncUtil
+    {
+        /// <summary>
+        /// Gets the appropriate Func&lt;&gt; or AotFunc&lt;&gt; delegate type for the given parameter count.
+        /// Supports 0-29 parameters.
+        /// </summary>
+        public static Type GetFuncType(int parameterCount)
+        {
+            if (parameterCount <= 16)
+                return GetStandardFuncType(parameterCount);
+
+            switch (parameterCount)
+            {
+                case 17:
+                    return typeof(AotFunc17<,,,,,,,,,,,,,,,,,>);
+                case 18:
+                    return typeof(AotFunc18<,,,,,,,,,,,,,,,,,,>);
+                case 19:
+                    return typeof(AotFunc19<,,,,,,,,,,,,,,,,,,,>);
+                case 20:
+                    return typeof(AotFunc20<,,,,,,,,,,,,,,,,,,,,>);
+                case 21:
+                    return typeof(AotFunc21<,,,,,,,,,,,,,,,,,,,,,>);
+                case 22:
+                    return typeof(AotFunc22<,,,,,,,,,,,,,,,,,,,,,,>);
+                case 23:
+                    return typeof(AotFunc23<,,,,,,,,,,,,,,,,,,,,,,,>);
+                case 24:
+                    return typeof(AotFunc24<,,,,,,,,,,,,,,,,,,,,,,,,>);
+                case 25:
+                    return typeof(AotFunc25<,,,,,,,,,,,,,,,,,,,,,,,,,>);
+                case 26:
+                    return typeof(AotFunc26<,,,,,,,,,,,,,,,,,,,,,,,,,,>);
+                case 27:
+                    return typeof(AotFunc27<,,,,,,,,,,,,,,,,,,,,,,,,,,,>);
+                case 28:
+                    return typeof(AotFunc28<,,,,,,,,,,,,,,,,,,,,,,,,,,,,>);
+                case 29:
+                    return typeof(AotFunc29<,,,,,,,,,,,,,,,,,,,,,,,,,,,,,>);
+                default:
+                    throw new NotSupportedException(
+                        $"NativeAOT does not support functions with {parameterCount} parameters. Maximum is 29."
+                    );
+            }
+        }
+
+        /// <summary>
+        /// Gets the standard .NET Func&lt;&gt; delegate type for 0-16 parameters.
+        /// Returns the open generic type (e.g., typeof(Func&lt;,&gt;)) that needs to be closed with MakeGenericType.
+        /// </summary>
+        public static Type GetStandardFuncType(int parameterCount)
+        {
+            switch (parameterCount)
+            {
+                case 0:
+                    return typeof(Func<>);
+                case 1:
+                    return typeof(Func<,>);
+                case 2:
+                    return typeof(Func<,,>);
+                case 3:
+                    return typeof(Func<,,,>);
+                case 4:
+                    return typeof(Func<,,,,>);
+                case 5:
+                    return typeof(Func<,,,,,>);
+                case 6:
+                    return typeof(Func<,,,,,,>);
+                case 7:
+                    return typeof(Func<,,,,,,,>);
+                case 8:
+                    return typeof(Func<,,,,,,,,>);
+                case 9:
+                    return typeof(Func<,,,,,,,,,>);
+                case 10:
+                    return typeof(Func<,,,,,,,,,,>);
+                case 11:
+                    return typeof(Func<,,,,,,,,,,,>);
+                case 12:
+                    return typeof(Func<,,,,,,,,,,,,>);
+                case 13:
+                    return typeof(Func<,,,,,,,,,,,,,>);
+                case 14:
+                    return typeof(Func<,,,,,,,,,,,,,,>);
+                case 15:
+                    return typeof(Func<,,,,,,,,,,,,,,,>);
+                case 16:
+                    return typeof(Func<,,,,,,,,,,,,,,,,>);
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(parameterCount),
+                        $"Standard Func<> only supports 0-16 parameters, got {parameterCount}"
+                    );
+            }
+        }
+
+        /// <summary>
+        /// Gets the standard .NET Action or Action&lt;&gt; delegate type for 0-16 parameters.
+        /// Returns the open generic type that needs to be closed with MakeGenericType (except for Action itself).
+        /// </summary>
+        public static Type GetStandardActionType(int parameterCount)
+        {
+            switch (parameterCount)
+            {
+                case 0:
+                    return typeof(Action);
+                case 1:
+                    return typeof(Action<>);
+                case 2:
+                    return typeof(Action<,>);
+                case 3:
+                    return typeof(Action<,,>);
+                case 4:
+                    return typeof(Action<,,,>);
+                case 5:
+                    return typeof(Action<,,,,>);
+                case 6:
+                    return typeof(Action<,,,,,>);
+                case 7:
+                    return typeof(Action<,,,,,,>);
+                case 8:
+                    return typeof(Action<,,,,,,,>);
+                case 9:
+                    return typeof(Action<,,,,,,,,>);
+                case 10:
+                    return typeof(Action<,,,,,,,,,>);
+                case 11:
+                    return typeof(Action<,,,,,,,,,,>);
+                case 12:
+                    return typeof(Action<,,,,,,,,,,,>);
+                case 13:
+                    return typeof(Action<,,,,,,,,,,,,>);
+                case 14:
+                    return typeof(Action<,,,,,,,,,,,,,>);
+                case 15:
+                    return typeof(Action<,,,,,,,,,,,,,,>);
+                case 16:
+                    return typeof(Action<,,,,,,,,,,,,,,,>);
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(parameterCount),
+                        $"Standard Action<> only supports 0-16 parameters, got {parameterCount}"
+                    );
+            }
+        }
+    }
+}

--- a/Source/ExcelDna.Integration/Registration/AsyncRegistration.cs
+++ b/Source/ExcelDna.Integration/Registration/AsyncRegistration.cs
@@ -22,9 +22,9 @@ namespace ExcelDna.Registration
         /// <summary>
         /// Wraps methods that are marked with [ExcelFunction] and:
         /// * Return IObservable, or
-        /// * Return Task or
+        /// * Return Task or 
         /// * Are marked with [ExcelAsyncFunction] attribute.
-        ///
+        /// 
         /// If the function takes as last parameter a CancellationToken, this will be hooked up to the async function cancellation.
         /// </summary>
         /// <remarks>NOTE: Currently supports functions with no more than sixteen parameters (fifteen for the native async),

--- a/Source/ExcelDna.Integration/Registration/AsyncRegistration.cs
+++ b/Source/ExcelDna.Integration/Registration/AsyncRegistration.cs
@@ -22,9 +22,9 @@ namespace ExcelDna.Registration
         /// <summary>
         /// Wraps methods that are marked with [ExcelFunction] and:
         /// * Return IObservable, or
-        /// * Return Task or 
+        /// * Return Task or
         /// * Are marked with [ExcelAsyncFunction] attribute.
-        /// 
+        ///
         /// If the function takes as last parameter a CancellationToken, this will be hooked up to the async function cancellation.
         /// </summary>
         /// <remarks>NOTE: Currently supports functions with no more than sixteen parameters (fifteen for the native async),
@@ -97,36 +97,67 @@ namespace ExcelDna.Registration
         }
 
 #if AOT_COMPATIBLE
+        [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL3050:RequiresDynamicCode", Justification = "SourceGenerator roots required Expression<TDelegate> shapes")]
+#endif
+        static LambdaExpression CreateLambdaForAsync(Expression body, string lambdaName, IEnumerable<ParameterExpression> parameters)
+        {
+#if AOT_COMPATIBLE
+            // In NativeAOT, we must explicitly specify the delegate type
+            // Expression.Lambda without a type tries to dynamically create delegate types, which fails
+            var paramList = parameters.ToList();
+            var paramTypes = paramList.Select(p => p.Type).ToList();
+            paramTypes.Add(body.Type); // Add return type as last element
+
+            int paramCount = paramList.Count;
+            if (paramCount > 29)
+            {
+                throw new NotSupportedException($"CreateLambdaForAsync: Async functions with more than 29 parameters are not supported in NativeAOT. Function '{lambdaName}' has {paramCount} parameters.");
+            }
+
+            // Get the appropriate delegate type (Func<> or AotFunc<>)
+            Type delegateType = AotExtendedFuncUtil.GetFuncType(paramCount);
+
+            // MakeGenericType works in AOT because the open generic types (Func<>, AotFunc17<>, etc.) are pre-compiled
+            delegateType = delegateType.MakeGenericType(paramTypes.ToArray());
+
+            // Now call Expression.Lambda with explicit delegate type
+            return Expression.Lambda(delegateType, body, lambdaName, parameters);
+#else
+            return Expression.Lambda(body, lambdaName, parameters);
+#endif
+        }
+
+#if AOT_COMPATIBLE
         [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL2060", Justification = "SourceGenerator adds methods to methodRefs")]
         [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("Trimming", "IL3050:RequiresDynamicCode", Justification = "SourceGenerator adds methods to methodRefs")]
 #endif
         static LambdaExpression WrapMethodRunTask(LambdaExpression functionLambda, List<object> returnCustomAttributes)
         {
             /* Either, from a lambda expression wrapping a method that looks like this:
-             * 
+             *
              *      static Task<string> myFunc(string name, int msDelay) {...}
-             * 
+             *
              *   we create a lambda expression that looks like this:
-             * 
+             *
              *      static object myFunc(string name, int msDelay)
              *      {
              *          return AsyncTaskUtil.RunTask<string>(
-             *              "myFunc:XXX", 
-             *              new object[] {(object)name, (object)msDelay}, 
+             *              "myFunc:XXX",
+             *              new object[] {(object)name, (object)msDelay},
              *              () => myFunc(name, msDelay));
              *      }
-             * 
+             *
              * Or, from a lambda expression wrapping a method that looks like this (not returning a Task):
-             * 
+             *
              *      static string myFunc(string name, int msDelay) {...}
-             * 
+             *
              *   we create a lambda expression that looks like this (with RunAsTaskXXX):
-             * 
+             *
              *      static object myFunc(string name, int msDelay)
              *      {
              *          return AsyncTaskUtil.RunAsTask<string>(
-             *              "myFunc:XXX", 
-             *              new object[] {(object)name, (object)msDelay}, 
+             *              "myFunc:XXX",
+             *              new object[] {(object)name, (object)msDelay},
              *              () => myFunc(name, msDelay));
              *      }
              */
@@ -147,7 +178,7 @@ namespace ExcelDna.Registration
             if (userType)
                 runMethodName = runMethodName.Replace("Task", "TaskObject");
 
-            // mi returns some kind of Task<T>. What is T? 
+            // mi returns some kind of Task<T>. What is T?
             var newReturnType = returnsTask ? functionLambda.ReturnType.GetGenericArguments()[0] : functionLambda.ReturnType;
             if (userType)
                 newReturnType = TaskObjectHandler.ReturnType();
@@ -176,7 +207,7 @@ namespace ExcelDna.Registration
             var callTaskRun = Expression.Call(runMethod, nameExp, paramsArrayExp, innerLambda);
 
             // Wrap with all the parameters
-            return Expression.Lambda(callTaskRun, functionLambda.Name, newParams);
+            return CreateLambdaForAsync(callTaskRun, functionLambda.Name, newParams);
         }
 
 #if AOT_COMPATIBLE
@@ -186,30 +217,30 @@ namespace ExcelDna.Registration
         static LambdaExpression WrapMethodRunTaskWithCancellation(LambdaExpression functionLambda, List<object> returnCustomAttributes)
         {
             /* Either, from a lambda expression that looks like this:
-             * 
+             *
              *      static Task<string> myFuncWithCancel(string name, int msDelay, CancellationToken ct) {...}
-             * 
+             *
              *   we create a lambda expression that looks like this:
-             * 
+             *
              *      static object crDelayedHello(string name, int msDelay)
              *      {
              *          return AsyncTaskUtil.RunTaskWithCancellation<string>(
-             *              "myFuncWithCancel:XXX", 
-             *              new object[] {(object)name, (object)msDelay}, 
+             *              "myFuncWithCancel:XXX",
+             *              new object[] {(object)name, (object)msDelay},
              *              (ct) => myFuncWithCancel(name, msDelay, ct));
              *      }
-             * 
+             *
              * Or, from a lambda expression that looks like this (not returning a Task):
-             * 
+             *
              *      static string myFuncWithCancel(string name, int msDelay, CancellationToken ct) {...}
-             * 
+             *
              *   we create a lambda expression that looks like this (with RunAsTaskXXX):
-             * 
+             *
              *      object crDelayedHello(string name, int msDelay)
              *      {
              *          return AsyncTaskUtil.RunAsTaskWithCancellation<string>(
-             *              "myFuncWithCancel:XXX", 
-             *              new object[] {(object)name, (object)msDelay}, 
+             *              "myFuncWithCancel:XXX",
+             *              new object[] {(object)name, (object)msDelay},
              *              (ct) => myFuncWithCancel(name, msDelay, ct));
              *      }
              */
@@ -230,7 +261,7 @@ namespace ExcelDna.Registration
             if (userType)
                 runMethodName = runMethodName.Replace("Task", "TaskObject");
 
-            // mi returns some kind of Task<T>. What is T? 
+            // mi returns some kind of Task<T>. What is T?
             var newReturnType = returnsTask ? functionLambda.ReturnType.GetGenericArguments()[0] : functionLambda.ReturnType;
             if (userType)
                 newReturnType = TaskObjectHandler.ReturnType();
@@ -267,7 +298,7 @@ namespace ExcelDna.Registration
             var callTaskRun = Expression.Call(runMethod, nameExp, paramsArrayExp, innerLambda);
 
             // Wrap with all the parameters, and Compile to a Delegate
-            return Expression.Lambda(callTaskRun, functionLambda.Name, newParams);
+            return CreateLambdaForAsync(callTaskRun, functionLambda.Name, newParams);
         }
 
         static LambdaExpression WrapMethodNativeAsyncTask(LambdaExpression functionLambda)
@@ -276,22 +307,22 @@ namespace ExcelDna.Registration
             throw new NotImplementedException("WrapMethodNativeAsyncTask is not supported in AOT.");
 #else
             /* Either, from a lambda expression that looks like this:
-             * 
+             *
              *      static Task<string> myFunc(string name, int msDelay) {...}
-             * 
+             *
              *   we create a lambda expression that looks like this:
-             * 
+             *
              *      static void myFunc(string name, int msDelay, ExcelAsyncHandle asyncHandle)
              *       {
              *           NativeAsyncTaskUtil.RunTask(() => myFunc(name, msDelay), asyncHandle);
              *       }
              *
              * Or, from a lambda expression that looks like this (not returning a Task):
-             * 
+             *
              *      static string myFunc(string name, int msDelay) {...}
-             * 
+             *
              *   we create a lambda expression that looks like this (with RunAsTaskXXX):
-             * 
+             *
              *      static void myFunc(string name, int msDelay, ExcelAsyncHandle asyncHandle)
              *       {
              *           NativeAsyncTaskUtil.RunAsTask(() => myFunc(name, msDelay), asyncHandle);
@@ -300,7 +331,7 @@ namespace ExcelDna.Registration
 
             // Either RunTask or RunAsTask, depending on whether the method returns Task<string> or string
             string runMethodName = ReturnsTask(functionLambda) ? "RunTask" : "RunAsTask";
-            // mi returns some kind of Task<T>. What is T? 
+            // mi returns some kind of Task<T>. What is T?
             var newReturnType = ReturnsTask(functionLambda) ? functionLambda.ReturnType.GetGenericArguments()[0] : functionLambda.ReturnType;
 
             // Make the new params for the wrapper - they look exactly like the functionLambda's parameters
@@ -320,7 +351,7 @@ namespace ExcelDna.Registration
 
             // Wrap with all the parameters
             var allParams = new List<ParameterExpression>(newParams) { asyncHandleParam };
-            return Expression.Lambda(callTaskRun, functionLambda.Name, allParams);
+            return CreateLambdaForAsync(callTaskRun, functionLambda.Name, allParams);
 #endif
         }
 
@@ -330,22 +361,22 @@ namespace ExcelDna.Registration
             throw new NotImplementedException("WrapMethodNativeAsyncTaskWithCancellation is not supported in AOT.");
 #else
             /* Either, from a lambda expression that looks like this:
-             * 
+             *
              *      static Task<string> myFunc(string name, int msDelay, CancellationToken ct) {...}
-             * 
+             *
              *   we create a lambda expression that looks like this:
-             * 
+             *
              *      static void myFunc(string name, int msDelay, ExcelAsyncHandle asyncHandle)
              *       {
              *           NativeAsyncTaskUtil.RunTaskWithCancellation((ct) => myFunc(name, msDelay, ct), asyncHandle);
              *       }
              *
              * Or, from a lambda expression that looks like this (not returning a Task):
-             * 
+             *
              *      static string myFunc(string name, int msDelay, CancellationToken ct) {...}
-             * 
+             *
              *   we create a lambda expression that looks like this (with RunAsTaskXXX):
-             * 
+             *
              *      static void myFunc(string name, int msDelay, ExcelAsyncHandle asyncHandle)
              *       {
              *           NativeAsyncTaskUtil.RunAsTaskWithCancellation((ct) => myFunc(name, msDelay, ct), asyncHandle);
@@ -354,7 +385,7 @@ namespace ExcelDna.Registration
 
             // Either RunTask or RunAsTask, depending on whether the method returns Task<string> or string
             string runMethodName = ReturnsTask(functionLambda) ? "RunTaskWithCancellation" : "RunAsTaskWithCancellation";
-            // mi returns some kind of Task<T>. What is T? 
+            // mi returns some kind of Task<T>. What is T?
             var newReturnType = ReturnsTask(functionLambda) ? functionLambda.ReturnType.GetGenericArguments()[0] : functionLambda.ReturnType;
             // Build up the RunTaskWithC... method with the right generic type argument
             var runMethod = typeof(NativeAsyncTaskUtil)
@@ -381,7 +412,7 @@ namespace ExcelDna.Registration
 
             // Wrap with all the parameters, and Compile to a Delegate
             var allParams = new List<ParameterExpression>(newParams) { asyncHandleParam };
-            return Expression.Lambda(callTaskRun, functionLambda.Name, allParams);
+            return CreateLambdaForAsync(callTaskRun, functionLambda.Name, allParams);
 #endif
         }
 
@@ -392,11 +423,11 @@ namespace ExcelDna.Registration
         static LambdaExpression WrapMethodObservable(LambdaExpression functionLambda, List<object> returnCustomAttributes)
         {
             /* Either, from a lambda expression that looks like this:
-             * 
+             *
              *      static IObservable<string> myFunc(string name, int msDelay) {...}
-             * 
+             *
              *   we create a lambda expression that looks like this:
-             * 
+             *
              *      static object myFunc(string name, int msDelay)
              *      {
              *          return ObservableRtdUtil.Observer<string>(          // obsMethod
@@ -406,7 +437,7 @@ namespace ExcelDna.Registration
              *      }
              */
 
-            // mi returns some kind of IObservable<T>. What is T? 
+            // mi returns some kind of IObservable<T>. What is T?
             Type returnType = functionLambda.ReturnType.GetGenericArguments()[0];
             bool userType = TaskObjectHandler.IsUserType(returnType);
             if (userType)
@@ -438,7 +469,7 @@ namespace ExcelDna.Registration
             var callTaskRun = Expression.Call(obsMethod, nameExp, paramsArrayExp, innerLambda);
 
             // Wrap with all the parameters, and Compile to a Delegate
-            return Expression.Lambda(callTaskRun, functionLambda.Name, newParams);
+            return CreateLambdaForAsync(callTaskRun, functionLambda.Name, newParams);
         }
     }
 }

--- a/Source/ExcelDna.Integration/Registration/AsyncRegistration.cs
+++ b/Source/ExcelDna.Integration/Registration/AsyncRegistration.cs
@@ -134,30 +134,30 @@ namespace ExcelDna.Registration
         static LambdaExpression WrapMethodRunTask(LambdaExpression functionLambda, List<object> returnCustomAttributes)
         {
             /* Either, from a lambda expression wrapping a method that looks like this:
-             *
+             * 
              *      static Task<string> myFunc(string name, int msDelay) {...}
-             *
+             * 
              *   we create a lambda expression that looks like this:
-             *
+             * 
              *      static object myFunc(string name, int msDelay)
              *      {
              *          return AsyncTaskUtil.RunTask<string>(
-             *              "myFunc:XXX",
-             *              new object[] {(object)name, (object)msDelay},
+             *              "myFunc:XXX", 
+             *              new object[] {(object)name, (object)msDelay}, 
              *              () => myFunc(name, msDelay));
              *      }
-             *
+             * 
              * Or, from a lambda expression wrapping a method that looks like this (not returning a Task):
-             *
+             * 
              *      static string myFunc(string name, int msDelay) {...}
-             *
+             * 
              *   we create a lambda expression that looks like this (with RunAsTaskXXX):
-             *
+             * 
              *      static object myFunc(string name, int msDelay)
              *      {
              *          return AsyncTaskUtil.RunAsTask<string>(
-             *              "myFunc:XXX",
-             *              new object[] {(object)name, (object)msDelay},
+             *              "myFunc:XXX", 
+             *              new object[] {(object)name, (object)msDelay}, 
              *              () => myFunc(name, msDelay));
              *      }
              */
@@ -178,7 +178,7 @@ namespace ExcelDna.Registration
             if (userType)
                 runMethodName = runMethodName.Replace("Task", "TaskObject");
 
-            // mi returns some kind of Task<T>. What is T?
+            // mi returns some kind of Task<T>. What is T? 
             var newReturnType = returnsTask ? functionLambda.ReturnType.GetGenericArguments()[0] : functionLambda.ReturnType;
             if (userType)
                 newReturnType = TaskObjectHandler.ReturnType();
@@ -217,30 +217,30 @@ namespace ExcelDna.Registration
         static LambdaExpression WrapMethodRunTaskWithCancellation(LambdaExpression functionLambda, List<object> returnCustomAttributes)
         {
             /* Either, from a lambda expression that looks like this:
-             *
+             * 
              *      static Task<string> myFuncWithCancel(string name, int msDelay, CancellationToken ct) {...}
-             *
+             * 
              *   we create a lambda expression that looks like this:
-             *
+             * 
              *      static object crDelayedHello(string name, int msDelay)
              *      {
              *          return AsyncTaskUtil.RunTaskWithCancellation<string>(
-             *              "myFuncWithCancel:XXX",
-             *              new object[] {(object)name, (object)msDelay},
+             *              "myFuncWithCancel:XXX", 
+             *              new object[] {(object)name, (object)msDelay}, 
              *              (ct) => myFuncWithCancel(name, msDelay, ct));
              *      }
-             *
+             * 
              * Or, from a lambda expression that looks like this (not returning a Task):
-             *
+             * 
              *      static string myFuncWithCancel(string name, int msDelay, CancellationToken ct) {...}
-             *
+             * 
              *   we create a lambda expression that looks like this (with RunAsTaskXXX):
-             *
+             * 
              *      object crDelayedHello(string name, int msDelay)
              *      {
              *          return AsyncTaskUtil.RunAsTaskWithCancellation<string>(
-             *              "myFuncWithCancel:XXX",
-             *              new object[] {(object)name, (object)msDelay},
+             *              "myFuncWithCancel:XXX", 
+             *              new object[] {(object)name, (object)msDelay}, 
              *              (ct) => myFuncWithCancel(name, msDelay, ct));
              *      }
              */
@@ -261,7 +261,7 @@ namespace ExcelDna.Registration
             if (userType)
                 runMethodName = runMethodName.Replace("Task", "TaskObject");
 
-            // mi returns some kind of Task<T>. What is T?
+            // mi returns some kind of Task<T>. What is T? 
             var newReturnType = returnsTask ? functionLambda.ReturnType.GetGenericArguments()[0] : functionLambda.ReturnType;
             if (userType)
                 newReturnType = TaskObjectHandler.ReturnType();
@@ -307,22 +307,22 @@ namespace ExcelDna.Registration
             throw new NotImplementedException("WrapMethodNativeAsyncTask is not supported in AOT.");
 #else
             /* Either, from a lambda expression that looks like this:
-             *
+             * 
              *      static Task<string> myFunc(string name, int msDelay) {...}
-             *
+             * 
              *   we create a lambda expression that looks like this:
-             *
+             * 
              *      static void myFunc(string name, int msDelay, ExcelAsyncHandle asyncHandle)
              *       {
              *           NativeAsyncTaskUtil.RunTask(() => myFunc(name, msDelay), asyncHandle);
              *       }
              *
              * Or, from a lambda expression that looks like this (not returning a Task):
-             *
+             * 
              *      static string myFunc(string name, int msDelay) {...}
-             *
+             * 
              *   we create a lambda expression that looks like this (with RunAsTaskXXX):
-             *
+             * 
              *      static void myFunc(string name, int msDelay, ExcelAsyncHandle asyncHandle)
              *       {
              *           NativeAsyncTaskUtil.RunAsTask(() => myFunc(name, msDelay), asyncHandle);
@@ -331,7 +331,7 @@ namespace ExcelDna.Registration
 
             // Either RunTask or RunAsTask, depending on whether the method returns Task<string> or string
             string runMethodName = ReturnsTask(functionLambda) ? "RunTask" : "RunAsTask";
-            // mi returns some kind of Task<T>. What is T?
+            // mi returns some kind of Task<T>. What is T? 
             var newReturnType = ReturnsTask(functionLambda) ? functionLambda.ReturnType.GetGenericArguments()[0] : functionLambda.ReturnType;
 
             // Make the new params for the wrapper - they look exactly like the functionLambda's parameters
@@ -361,22 +361,22 @@ namespace ExcelDna.Registration
             throw new NotImplementedException("WrapMethodNativeAsyncTaskWithCancellation is not supported in AOT.");
 #else
             /* Either, from a lambda expression that looks like this:
-             *
+             * 
              *      static Task<string> myFunc(string name, int msDelay, CancellationToken ct) {...}
-             *
+             * 
              *   we create a lambda expression that looks like this:
-             *
+             * 
              *      static void myFunc(string name, int msDelay, ExcelAsyncHandle asyncHandle)
              *       {
              *           NativeAsyncTaskUtil.RunTaskWithCancellation((ct) => myFunc(name, msDelay, ct), asyncHandle);
              *       }
              *
              * Or, from a lambda expression that looks like this (not returning a Task):
-             *
+             * 
              *      static string myFunc(string name, int msDelay, CancellationToken ct) {...}
-             *
+             * 
              *   we create a lambda expression that looks like this (with RunAsTaskXXX):
-             *
+             * 
              *      static void myFunc(string name, int msDelay, ExcelAsyncHandle asyncHandle)
              *       {
              *           NativeAsyncTaskUtil.RunAsTaskWithCancellation((ct) => myFunc(name, msDelay, ct), asyncHandle);
@@ -385,7 +385,7 @@ namespace ExcelDna.Registration
 
             // Either RunTask or RunAsTask, depending on whether the method returns Task<string> or string
             string runMethodName = ReturnsTask(functionLambda) ? "RunTaskWithCancellation" : "RunAsTaskWithCancellation";
-            // mi returns some kind of Task<T>. What is T?
+            // mi returns some kind of Task<T>. What is T? 
             var newReturnType = ReturnsTask(functionLambda) ? functionLambda.ReturnType.GetGenericArguments()[0] : functionLambda.ReturnType;
             // Build up the RunTaskWithC... method with the right generic type argument
             var runMethod = typeof(NativeAsyncTaskUtil)
@@ -423,11 +423,11 @@ namespace ExcelDna.Registration
         static LambdaExpression WrapMethodObservable(LambdaExpression functionLambda, List<object> returnCustomAttributes)
         {
             /* Either, from a lambda expression that looks like this:
-             *
+             * 
              *      static IObservable<string> myFunc(string name, int msDelay) {...}
-             *
+             * 
              *   we create a lambda expression that looks like this:
-             *
+             * 
              *      static object myFunc(string name, int msDelay)
              *      {
              *          return ObservableRtdUtil.Observer<string>(          // obsMethod
@@ -437,7 +437,7 @@ namespace ExcelDna.Registration
              *      }
              */
 
-            // mi returns some kind of IObservable<T>. What is T?
+            // mi returns some kind of IObservable<T>. What is T? 
             Type returnType = functionLambda.ReturnType.GetGenericArguments()[0];
             bool userType = TaskObjectHandler.IsUserType(returnType);
             if (userType)

--- a/Source/ExcelDna.Integration/Registration/ExcelCommandRegistration.cs
+++ b/Source/ExcelDna.Integration/Registration/ExcelCommandRegistration.cs
@@ -14,7 +14,7 @@ namespace ExcelDna.Registration
     // Maybe one day we'll do Command/Function unification
     // For now we mirror core Excel-DNA approach
     // Note that Excel-DNA does support ExcelCommands that take parameters and return values.
-    // However, these are not available as worksheet functions, and are unusual -
+    // However, these are not available as worksheet functions, and are unusual - 
     // so the ExcelCommandRegistration here doesn't support attributes on such parameters or return values.
     public class ExcelCommandRegistration
     {

--- a/Source/ExcelDna.Integration/Registration/ExcelCommandRegistration.cs
+++ b/Source/ExcelDna.Integration/Registration/ExcelCommandRegistration.cs
@@ -14,7 +14,7 @@ namespace ExcelDna.Registration
     // Maybe one day we'll do Command/Function unification
     // For now we mirror core Excel-DNA approach
     // Note that Excel-DNA does support ExcelCommands that take parameters and return values.
-    // However, these are not available as worksheet functions, and are unusual - 
+    // However, these are not available as worksheet functions, and are unusual -
     // so the ExcelCommandRegistration here doesn't support attributes on such parameters or return values.
     public class ExcelCommandRegistration
     {
@@ -56,7 +56,31 @@ namespace ExcelDna.Registration
             var paramExprs = methodInfo.GetParameters()
                              .Select(pi => Expression.Parameter(pi.ParameterType, pi.Name))
                              .ToList();
+
+#if AOT_COMPATIBLE
+            // Commands typically have 0-2 parameters, but use explicit delegate type for AOT safety
+            int paramCount = paramExprs.Count;
+            if (paramCount > 16)
+            {
+                throw new NotSupportedException(
+                    $"ExcelCommandRegistration: Commands with more than 16 parameters are not supported. Command '{methodInfo.Name}' has {paramCount} parameters."
+                );
+            }
+
+            Type delegateType = AotExtendedFuncUtil.GetStandardActionType(paramCount);
+
+            // MakeGenericType only if we have parameters (Action itself is not generic)
+            if (paramCount > 0)
+            {
+                delegateType = delegateType.MakeGenericType(
+                    paramExprs.Select(p => p.Type).ToArray()
+                );
+            }
+
+            CommandLambda = Expression.Lambda(delegateType, Expression.Call(methodInfo, paramExprs), methodInfo.Name, paramExprs);
+#else
             CommandLambda = Expression.Lambda(Expression.Call(methodInfo, paramExprs), methodInfo.Name, paramExprs);
+#endif
 
             var allMethodAttributes = methodInfo.GetCustomAttributes(true);
             foreach (var att in allMethodAttributes)

--- a/Source/ExcelDna.Integration/Registration/ExcelFunctionRegistration.cs
+++ b/Source/ExcelDna.Integration/Registration/ExcelFunctionRegistration.cs
@@ -43,7 +43,7 @@ namespace ExcelDna.Registration
         /// <summary>
         /// Creates a new ExcelFunctionRegistration with the given LambdaExpression.
         /// Uses the passes in attributes for registration.
-        /// 
+        ///
         /// The number of ExcelParameterRegistrations passed in must match the number of parameters in the LambdaExpression.
         /// </summary>
         /// <param name="functionLambda"></param>
@@ -152,7 +152,12 @@ namespace ExcelDna.Registration
         {
             try
             {
-#if !AOT_COMPATIBLE
+#if AOT_COMPATIBLE
+                if (paramExprs.Count > 16)
+                {
+                    return Expression.Lambda(GetAotExtendedDelegateType(methodInfo), Expression.Call(methodInfo, paramExprs), methodInfo.Name, paramExprs);
+                }
+#else
                 if (paramExprs.Count > 16)
                 {
                     return Expression.Lambda(GetExtendedDelegateType(methodInfo), Expression.Call(methodInfo, paramExprs), methodInfo.Name, paramExprs);
@@ -174,6 +179,45 @@ namespace ExcelDna.Registration
         {
             return ex.Message?.IndexOf("missing native code or metadata", StringComparison.OrdinalIgnoreCase) >= 0;
         }
+
+#if AOT_COMPATIBLE
+        private static Type GetAotExtendedDelegateType(MethodInfo methodInfo)
+        {
+            try
+            {
+                if (methodInfo.ReturnType != typeof(void))
+                {
+                    if (methodInfo.GetParameters().Length >= 17 && methodInfo.GetParameters().Length <= 29)
+                    {
+                       Type genericBase = AotExtendedFuncUtil.GetFuncType(methodInfo.GetParameters().Length);
+
+                        var args = methodInfo.GetParameters().Select(p => p.ParameterType)
+                            .Concat(new[] { methodInfo.ReturnType })
+                            .ToArray();
+
+                        var result = genericBase.MakeGenericType(args);
+                        return result;
+                    }
+                    else
+                    {
+                        throw new NotSupportedException(
+                            $"NativeAOT does not support functions with {methodInfo.GetParameters().Length} parameters. Maximum is 29."
+                        );
+                    }
+                }
+                else
+                {
+                    throw new NotSupportedException(
+                        $"NativeAOT does not support command functions (void return) with {methodInfo.GetParameters().Length} parameters (>16)."
+                    );
+                }
+            }
+            catch (Exception ex)
+            {
+                throw;
+            }
+        }
+#endif
 
 #if !AOT_COMPATIBLE
         private static Type GetExtendedDelegateType(MethodInfo methodInfo)

--- a/Source/ExcelDna.Integration/Registration/ExcelFunctionRegistration.cs
+++ b/Source/ExcelDna.Integration/Registration/ExcelFunctionRegistration.cs
@@ -43,7 +43,7 @@ namespace ExcelDna.Registration
         /// <summary>
         /// Creates a new ExcelFunctionRegistration with the given LambdaExpression.
         /// Uses the passes in attributes for registration.
-        ///
+        /// 
         /// The number of ExcelParameterRegistrations passed in must match the number of parameters in the LambdaExpression.
         /// </summary>
         /// <param name="functionLambda"></param>

--- a/Source/ExcelDna.Integration/Registration/FunctionExecutionRegistration.cs
+++ b/Source/ExcelDna.Integration/Registration/FunctionExecutionRegistration.cs
@@ -136,6 +136,7 @@ namespace ExcelDna.Registration
             var returnValueFromResult = Expr.Assign(fhArgsReturnValue, Expr.Convert(result, typeof(object)));
             // : result = function(arg0, arg1)
             var resultFromInnerCall = Expr.Assign(result, Expr.Invoke(functionLambda, outerParams));
+            
             // Build the Lambda wrapper, with the original parameters
 #if AOT_COMPATIBLE
             var lambda = CreateLambdaForFunctionExecution(

--- a/Source/ExcelDna.Integration/Registration/FunctionExecutionRegistration.cs
+++ b/Source/ExcelDna.Integration/Registration/FunctionExecutionRegistration.cs
@@ -70,7 +70,7 @@ namespace ExcelDna.Registration
             //        //     // So Default value will be returned....?????
             //        //     fhArgs.Exception = null;
             //        // }
-            //        // else
+            //        // else 
             //        if (fhArgs.FlowBehavior == FlowBehavior.Return)
             //        {
             //            // Clear the Exception and return the ReturnValue instead
@@ -92,7 +92,7 @@ namespace ExcelDna.Registration
             //        fh.OnExit(fhArgs);
             //        // NOTE: fhArgs.ReturnValue is not used again here...!
             //    }
-            //
+            //    
             //    return result;
             //  }
             // }
@@ -103,7 +103,7 @@ namespace ExcelDna.Registration
             var mh = Expression.Constant(handler);
             var funcName = Expression.Constant(functionName);
 
-            // Prepare the functionHandlerArgs that will be threaded through the handler,
+            // Prepare the functionHandlerArgs that will be threaded through the handler, 
             // and a bunch of expressions that access various properties on it.
             var fhArgs = Expr.Variable(typeof(FunctionExecutionArgs), "fhArgs");
             var fhArgsReturnValue = SymbolExtensions.GetProperty(fhArgs, (ExcelDna.Registration.FunctionExecutionArgs mea) => mea.ReturnValue);
@@ -136,7 +136,7 @@ namespace ExcelDna.Registration
             var returnValueFromResult = Expr.Assign(fhArgsReturnValue, Expr.Convert(result, typeof(object)));
             // : result = function(arg0, arg1)
             var resultFromInnerCall = Expr.Assign(result, Expr.Invoke(functionLambda, outerParams));
-
+            // Build the Lambda wrapper, with the original parameters
 #if AOT_COMPATIBLE
             var lambda = CreateLambdaForFunctionExecution(
                 Expr.Block(new[] { fhArgs, result },

--- a/Source/ExcelDna.Integration/Registration/FunctionExecutionRegistration.cs
+++ b/Source/ExcelDna.Integration/Registration/FunctionExecutionRegistration.cs
@@ -70,7 +70,7 @@ namespace ExcelDna.Registration
             //        //     // So Default value will be returned....?????
             //        //     fhArgs.Exception = null;
             //        // }
-            //        // else 
+            //        // else
             //        if (fhArgs.FlowBehavior == FlowBehavior.Return)
             //        {
             //            // Clear the Exception and return the ReturnValue instead
@@ -92,7 +92,7 @@ namespace ExcelDna.Registration
             //        fh.OnExit(fhArgs);
             //        // NOTE: fhArgs.ReturnValue is not used again here...!
             //    }
-            //    
+            //
             //    return result;
             //  }
             // }
@@ -103,7 +103,7 @@ namespace ExcelDna.Registration
             var mh = Expression.Constant(handler);
             var funcName = Expression.Constant(functionName);
 
-            // Prepare the functionHandlerArgs that will be threaded through the handler, 
+            // Prepare the functionHandlerArgs that will be threaded through the handler,
             // and a bunch of expressions that access various properties on it.
             var fhArgs = Expr.Variable(typeof(FunctionExecutionArgs), "fhArgs");
             var fhArgsReturnValue = SymbolExtensions.GetProperty(fhArgs, (ExcelDna.Registration.FunctionExecutionArgs mea) => mea.ReturnValue);
@@ -137,7 +137,41 @@ namespace ExcelDna.Registration
             // : result = function(arg0, arg1)
             var resultFromInnerCall = Expr.Assign(result, Expr.Invoke(functionLambda, outerParams));
 
-            // Build the Lambda wrapper, with the original parameters
+#if AOT_COMPATIBLE
+            var lambda = CreateLambdaForFunctionExecution(
+                Expr.Block(new[] { fhArgs, result },
+                     Expr.Assign(fhArgs, newfhArgs),
+                     Expr.Assign(result, Expr.Default(result.Type)),
+                     Expr.TryCatchFinally(
+                        Expr.Block(
+                            onEntry,
+                            Expr.IfThenElse(
+                                Expr.Equal(fhArgsFlowBehaviour, Expr.Constant(FlowBehavior.Return)),
+                                resultFromReturnValue,
+                                Expr.Block(
+                                    resultFromInnerCall,
+                                    returnValueFromResult,
+                                    onSuccess,
+                                    resultFromReturnValue))),
+                        onExit,
+                        Expr.Catch(ex,
+                            Expr.Block(
+                                Expr.Assign(fhArgsException, ex),
+                                onException,
+                                Expr.IfThenElse(
+                                    Expr.Equal(fhArgsFlowBehaviour, Expr.Constant(FlowBehavior.Return)),
+                                    Expr.Block(
+                                        Expr.Assign(fhArgsException, Expr.Constant(null, typeof(Exception))),
+                                        resultFromReturnValue),
+                                    Expr.IfThenElse(
+                                        Expr.Equal(fhArgsFlowBehaviour, Expr.Constant(FlowBehavior.ThrowException)),
+                                        Expr.Throw(fhArgsException),
+                                        Expr.Rethrow()))))
+                        ),
+                    result),
+                functionName,
+                outerParams);
+#else
             var lambda = Expr.Lambda(
                 Expr.Block(new[] { fhArgs, result },
                      Expr.Assign(fhArgs, newfhArgs),
@@ -171,8 +205,28 @@ namespace ExcelDna.Registration
                     result),
                 functionName,
                 outerParams);
+#endif
             return lambda;
         }
+
+#if AOT_COMPATIBLE
+        static LambdaExpression CreateLambdaForFunctionExecution(Expression body, string lambdaName, IEnumerable<ParameterExpression> parameters)
+        {
+            var paramList = parameters.ToList();
+            var paramTypes = paramList.Select(p => p.Type).ToList();
+            paramTypes.Add(body.Type);
+
+            int paramCount = paramList.Count;
+            if (paramCount > 29)
+            {
+                throw new NotSupportedException($"CreateLambdaForFunctionExecution: Functions with more than 29 parameters not supported. Function '{lambdaName}' has {paramCount} parameters.");
+            }
+
+            Type delegateType = AotExtendedFuncUtil.GetFuncType(paramCount);
+            delegateType = delegateType.MakeGenericType(paramTypes.ToArray());
+            return Expr.Lambda(delegateType, body, lambdaName, parameters);
+        }
+#endif
 
         static void ApplyMethodHandlers(ExcelFunctionRegistration reg, IEnumerable<IFunctionExecutionHandler> handlers)
         {

--- a/Source/ExcelDna.Integration/Registration/ParameterConversionRegistration.cs
+++ b/Source/ExcelDna.Integration/Registration/ParameterConversionRegistration.cs
@@ -50,20 +50,20 @@ namespace ExcelDna.Registration
             //      public static string dnaParameterConvertTest(double? optTest) {   };
             //
             // with conversions convert1 and convert2 taking us from Type1 to double?
-            //
+            // 
             // to
-            //      public static string dnaParameterConvertTest(Type1 optTest)
-            //      {
+            //      public static string dnaParameterConvertTest(Type1 optTest) 
+            //      {   
             //          return convertRet2(convertRet1(
             //                      dnaParameterConvertTest(
             //                          paramConvert1(optTest)
             //                            )));
             //      };
-            //
+            // 
             // and then with a conversion from object to Type1, resulting in
             //
-            //      public static string dnaParameterConvertTest(object optTest)
-            //      {
+            //      public static string dnaParameterConvertTest(object optTest) 
+            //      {   
             //          return convertRet2(convertRet1(
             //                      dnaParameterConvertTest(
             //                          paramConvert1(paramConvert2(optTest))

--- a/Source/ExcelDna.Integration/Registration/ParameterConversionRegistration.cs
+++ b/Source/ExcelDna.Integration/Registration/ParameterConversionRegistration.cs
@@ -50,20 +50,20 @@ namespace ExcelDna.Registration
             //      public static string dnaParameterConvertTest(double? optTest) {   };
             //
             // with conversions convert1 and convert2 taking us from Type1 to double?
-            // 
+            //
             // to
-            //      public static string dnaParameterConvertTest(Type1 optTest) 
-            //      {   
+            //      public static string dnaParameterConvertTest(Type1 optTest)
+            //      {
             //          return convertRet2(convertRet1(
             //                      dnaParameterConvertTest(
             //                          paramConvert1(optTest)
             //                            )));
             //      };
-            // 
+            //
             // and then with a conversion from object to Type1, resulting in
             //
-            //      public static string dnaParameterConvertTest(object optTest) 
-            //      {   
+            //      public static string dnaParameterConvertTest(object optTest)
+            //      {
             //          return convertRet2(convertRet1(
             //                      dnaParameterConvertTest(
             //                          paramConvert1(paramConvert2(optTest))
@@ -149,7 +149,26 @@ namespace ExcelDna.Registration
         {
             try
             {
+#if AOT_COMPATIBLE
+                var paramList = parameters.ToList();
+                var paramTypes = paramList.Select(p => p.Type).ToList();
+                paramTypes.Add(body.Type);
+
+                int paramCount = paramList.Count;
+                if (paramCount > 29)
+                {
+                    throw new NotSupportedException(
+                        $"CreateLambdaWithAotContext: Functions with more than 29 parameters are not supported in NativeAOT. Function '{lambdaName}' has {paramCount} parameters."
+                    );
+                }
+
+                Type delegateType = AotExtendedFuncUtil.GetFuncType(paramCount);
+                delegateType = delegateType.MakeGenericType(paramTypes.ToArray());
+
+                return Expr.Lambda(delegateType, body, lambdaName, parameters);
+#else
                 return Expr.Lambda(body, lambdaName, parameters);
+#endif
             }
             catch (NotSupportedException ex) when (IsMissingNativeMetadata(ex))
             {

--- a/Source/ExcelDna.SourceGenerator.NativeAOT/Util.cs
+++ b/Source/ExcelDna.SourceGenerator.NativeAOT/Util.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
 using System.Collections.Generic;
 using System.Linq;
+using System;
 
 namespace ExcelDna.SourceGenerator.NativeAOT
 {

--- a/Source/ExcelDna.SourceGenerator.NativeAOT/Util.cs
+++ b/Source/ExcelDna.SourceGenerator.NativeAOT/Util.cs
@@ -83,10 +83,31 @@ namespace ExcelDna.SourceGenerator.NativeAOT
 
         static string BuildMethodType(IEnumerable<string> parameterTypeNames, ITypeSymbol returnType, bool returnsVoid)
         {
-            string parameters = string.Join(", ", parameterTypeNames);
-            return returnsVoid
-                ? $"Action{(string.IsNullOrWhiteSpace(parameters) ? null : $"<{parameters}>")}"
-                : $"Func<{(string.IsNullOrWhiteSpace(parameters) ? null : $"{parameters}, ")}{GetFullTypeName(returnType)}>";
+            var paramList = parameterTypeNames.ToList();
+            int paramCount = paramList.Count;
+
+            string parameters = string.Join(", ", paramList);
+
+            if (returnsVoid)
+            {
+                if (paramCount > 16)
+                {
+                    throw new NotSupportedException($"NativeAOT does not support command functions (void return) with {paramCount} parameters (>16).");
+                }
+                return $"Action{(string.IsNullOrWhiteSpace(parameters) ? null : $"<{parameters}>")}";
+            }
+            else
+            {
+                if (paramCount > 16)
+                {
+                    if (paramCount > 29)
+                    {
+                        throw new NotSupportedException($"NativeAOT does not support functions with {paramCount} parameters. Maximum is 29.");
+                    }
+                    return $"ExcelDna.Registration.AotFunc{paramCount}<{parameters}, {GetFullTypeName(returnType)}>";
+                }
+                return $"Func<{(string.IsNullOrWhiteSpace(parameters) ? null : $"{parameters}, ")}{GetFullTypeName(returnType)}>";
+            }
         }
 
         static string GetPostParameterConversionInputTypeName(IParameterSymbol parameter)


### PR DESCRIPTION
Currently, AOT compilation doesn't support Excel functions with more than 16 arguments, I've added additional delegate types and changed the generation / function registration flows to make it work.