### PR TITLE
Fix NativeAOT COM/Ribbon interop and AOT publish flow

### DIFF
--- a/Package/Excel-DNA.Interop/Excel-DNA.Interop.nuspec
+++ b/Package/Excel-DNA.Interop/Excel-DNA.Interop.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>Excel-DNA.Interop</id>
-    <version>15.0.1</version>
+    <version>16.0.0</version>
     <title>Excel-DNA - Primary Interop Assemblies for Excel</title>
     <authors>Excel-DNA Contributors</authors>
     <owners>excel-dna</owners>
@@ -10,15 +10,17 @@
     <repository type="git" url="https://github.com/Excel-DNA/ExcelDna" />
     <icon>images\ExcelDna-nu.png</icon>
     <license type="expression">MIT</license>
+    <readme>README.md</readme>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>This package is deprecated, and has been replaced by ExcelDna.Interop - https://www.nuget.org/packages/ExcelDna.Interop/.</description>
     <summary>Provides a selection of Excel Primary Interop Assemblies</summary>
     <tags>Excel Interop PIA ExcelDna</tags>
     <dependencies>
-      <dependency id="ExcelDna.Interop" version="[15.0.1]" />
+      <dependency id="ExcelDna.Interop" version="[16.0.0]" />
     </dependencies>
   </metadata>
   <files>
       <file src="..\images\ExcelDna-nu.png" target="images\" />
+      <file src="README.md" target="" />
     </files>
 </package>

--- a/Package/Excel-DNA.Interop/README.md
+++ b/Package/Excel-DNA.Interop/README.md
@@ -1,0 +1,5 @@
+# Excel-DNA.Interop
+
+This package is deprecated. Use [ExcelDna.Interop](https://www.nuget.org/packages/ExcelDna.Interop/) instead.
+
+The dependency on `ExcelDna.Interop` supplies the Microsoft Office primary interop assemblies used by Excel-DNA add-ins.

--- a/Package/ExcelDna.Interop.Dao/ExcelDna.Interop.Dao.nuspec
+++ b/Package/ExcelDna.Interop.Dao/ExcelDna.Interop.Dao.nuspec
@@ -8,6 +8,7 @@
         <projectUrl>http://excel-dna.net</projectUrl>
         <icon>images\ExcelDna-nu.png</icon>
         <license type="expression">MIT</license>
+        <readme>README.md</readme>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Provides a local copy of the Microsoft.Office.Interop.Access.Dao.dll primary interop assembly from Microsoft Office.</description>
         <summary>Provides the Primary Interop Assembly for the Access DAO library.</summary>
@@ -24,5 +25,6 @@
       <file src="lib\Microsoft.Office.Interop.Access.Dao.dll" target="lib\net6.0-windows7.0\" />
       <file src="build\ExcelDna.Interop.Dao.targets" target="build" />
       <file src="..\images\ExcelDna-nu.png" target="images\" />
+      <file src="README.md" target="" />
     </files>
 </package>

--- a/Package/ExcelDna.Interop.Dao/README.md
+++ b/Package/ExcelDna.Interop.Dao/README.md
@@ -1,0 +1,7 @@
+# ExcelDna.Interop.Dao
+
+This package provides a local copy of the `Microsoft.Office.Interop.Access.Dao.dll` primary interop assembly for the Microsoft Access DAO library.
+
+The assembly is available for .NET Framework 4.5.2 and `net6.0-windows7.0` projects. The package configures C# and Visual Basic projects to embed the interop types and not copy the assembly to the output directory. F# projects are excluded from that build behavior.
+
+For Excel-DNA documentation, see [excel-dna.net](https://excel-dna.net/).

--- a/Package/ExcelDna.Interop/ExcelDna.Interop.nuspec
+++ b/Package/ExcelDna.Interop/ExcelDna.Interop.nuspec
@@ -8,6 +8,7 @@
         <projectUrl>http://excel-dna.net</projectUrl>
         <icon>images\ExcelDna-nu.png</icon>
         <license type="expression">MIT</license>
+        <readme>README.md</readme>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>Provides a local copy of the Primary Interop Assemblies from Microsoft Office: Microsoft.Office.Interop.Excel.dll, Office.dll, Microsoft.Vbe.Interop.dll.</description>
         <summary>Provides a selection of Excel Primary Interop Assemblies</summary>
@@ -28,5 +29,6 @@
       <file src="lib\office.dll" target="lib\net6.0-windows7.0" />
       <file src="build\ExcelDna.Interop.targets" target="build\" />
       <file src="..\images\ExcelDna-nu.png" target="images\" />
+      <file src="README.md" target="" />
     </files>
 </package>

--- a/Package/ExcelDna.Interop/README.md
+++ b/Package/ExcelDna.Interop/README.md
@@ -1,0 +1,11 @@
+# ExcelDna.Interop
+
+This package provides local copies of these Microsoft Office primary interop assemblies:
+
+- `Microsoft.Office.Interop.Excel.dll`
+- `Microsoft.Vbe.Interop.dll`
+- `office.dll`
+
+The assemblies are available for .NET Framework 4.5.2 and `net6.0-windows7.0` projects. The package configures C# and Visual Basic projects to embed the interop types and not copy the assemblies to the output directory. F# projects are excluded from that build behavior.
+
+For Excel-DNA documentation, see [excel-dna.net](https://excel-dna.net/).

--- a/Package/package-interop.cmd
+++ b/Package/package-interop.cmd
@@ -12,13 +12,13 @@ if not exist "%outputPath%" mkdir "%outputPath%"
 
 echo on
 
-nuget.exe pack "%basePath%\Excel-DNA.Interop\Excel-DNA.Interop.nuspec" -BasePath "%basePath%\Excel-DNA.Interop" -OutputDirectory "%outputPath%" -Verbosity detailed -NonInteractive -Prop ExcelDnaVersion="%ExcelDnaVersion%"
+"%basePath%\nuget.exe" pack "%basePath%\Excel-DNA.Interop\Excel-DNA.Interop.nuspec" -BasePath "%basePath%\Excel-DNA.Interop" -OutputDirectory "%outputPath%" -Verbosity detailed -NonInteractive -Prop ExcelDnaVersion="%ExcelDnaVersion%"
 @if errorlevel 1 goto end
 
-nuget.exe pack "%basePath%\ExcelDna.Interop\ExcelDna.Interop.nuspec" -BasePath "%basePath%\ExcelDna.Interop" -OutputDirectory "%outputPath%" -Verbosity detailed -NonInteractive
+"%basePath%\nuget.exe" pack "%basePath%\ExcelDna.Interop\ExcelDna.Interop.nuspec" -BasePath "%basePath%\ExcelDna.Interop" -OutputDirectory "%outputPath%" -Verbosity detailed -NonInteractive
 @if errorlevel 1 goto end
 
-nuget.exe pack "%basePath%\ExcelDna.Interop.Dao\ExcelDna.Interop.Dao.nuspec" -BasePath "%basePath%\ExcelDna.Interop.Dao" -OutputDirectory "%outputPath%" -Verbosity detailed -NonInteractive
+"%basePath%\nuget.exe" pack "%basePath%\ExcelDna.Interop.Dao\ExcelDna.Interop.Dao.nuspec" -BasePath "%basePath%\ExcelDna.Interop.Dao" -OutputDirectory "%outputPath%" -Verbosity detailed -NonInteractive
 @if errorlevel 1 goto end
 
 :end

--- a/Package/push-interop.cmd
+++ b/Package/push-interop.cmd
@@ -7,13 +7,13 @@ set outputPath=%basePath%\nupkg
 
 if not exist "%outputPath%" mkdir "%outputPath%"
 
-nuget.exe push "%outputPath%\Excel-DNA.Interop.15.0.1.nupkg" -Source  https://api.nuget.org/v3/index.json -Verbosity detailed -NonInteractive
+nuget.exe push "%outputPath%\Excel-DNA.Interop.16.0.0.nupkg" -Source  https://api.nuget.org/v3/index.json -Verbosity detailed -NonInteractive
 @if errorlevel 1 goto end
 
-nuget.exe push "%outputPath%\ExcelDna.Interop.15.0.1.nupkg" -Source  https://api.nuget.org/v3/index.json -Verbosity detailed -NonInteractive
+nuget.exe push "%outputPath%\ExcelDna.Interop.16.0.0.nupkg" -Source  https://api.nuget.org/v3/index.json -Verbosity detailed -NonInteractive
 @if errorlevel 1 goto end
 
-nuget.exe push "%outputPath%\ExcelDna.Interop.Dao.15.0.1.nupkg" -Source  https://api.nuget.org/v3/index.json -Verbosity detailed -NonInteractive
+nuget.exe push "%outputPath%\ExcelDna.Interop.Dao.16.0.0.nupkg" -Source  https://api.nuget.org/v3/index.json -Verbosity detailed -NonInteractive
 @if errorlevel 1 goto end
 
 :end

--- a/Source/ExcelDna.Integration/ComInterop/ComServer.cs
+++ b/Source/ExcelDna.Integration/ComInterop/ComServer.cs
@@ -95,6 +95,7 @@ namespace ExcelDna.ComInterop
                 ComWrappers cw = new System.Runtime.InteropServices.Marshalling.StrategyBasedComWrappers();
                 nint ptr = cw.GetOrCreateComInterfaceForObject(factory, CreateComInterfaceFlags.None);
                 HRESULT hrQI = Marshal.QueryInterface(ptr, in iid, out ppunk);
+                Marshal.Release(ptr);
 #else
                 IntPtr punkFactory = Marshal.GetIUnknownForObject(factory);
                 HRESULT hrQI = Marshal.QueryInterface(punkFactory, ref iid, out ppunk);

--- a/Source/ExcelDna.Integration/ComInterop/DummyComAddIn.cs
+++ b/Source/ExcelDna.Integration/ComInterop/DummyComAddIn.cs
@@ -14,24 +14,29 @@ namespace ExcelDna.Integration.ComInterop
     [GeneratedComClass]
     internal partial class DummyComAddIn : Generator.Interfaces.IDTExtensibility2
     {
+        private const int S_OK = 0;
+        private const int E_NOTIMPL = unchecked((int)0x80004001);
+
         public int GetTypeInfoCount(out uint pctinfo)
         {
-            throw new NotImplementedException();
+            pctinfo = 0;
+            return S_OK;
         }
 
         public int GetTypeInfo(uint iTInfo, uint lcid, out nint ppTInfo)
         {
-            throw new NotImplementedException();
+            ppTInfo = 0;
+            return E_NOTIMPL;
         }
 
-        public int GetIDsOfNames(Guid riid, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 2)] string[] rgszNames, uint cNames, uint lcid, [In][Out][MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] int[] rgDispId)
+        public int GetIDsOfNames(in Guid riid, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 2)] string[] rgszNames, uint cNames, uint lcid, [In][Out][MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] int[] rgDispId)
         {
-            throw new NotImplementedException();
+            return E_NOTIMPL;
         }
 
-        public int Invoke(int dispIdMember, Guid riid, uint lcid, INVOKEKIND wFlags, [MarshalUsing(typeof(Generator.Interfaces.DispParamsMarshaller))] in Generator.Interfaces.DispParams pDispParams, nint pVarResult, nint pExcepInfo, nint puArgErr)
+        public int Invoke(int dispIdMember, in Guid riid, uint lcid, ushort wFlags, [MarshalUsing(typeof(Generator.Interfaces.DispParamsMarshaller))] in Generator.Interfaces.DispParams pDispParams, nint pVarResult, nint pExcepInfo, nint puArgErr)
         {
-            throw new NotImplementedException();
+            return E_NOTIMPL;
         }
 
         #region IDTExtensibility2 interface

--- a/Source/ExcelDna.Integration/ComInterop/Generator/ExcelObserverRtdServer.cs
+++ b/Source/ExcelDna.Integration/ComInterop/Generator/ExcelObserverRtdServer.cs
@@ -12,6 +12,9 @@ namespace ExcelDna.Integration.ComInterop.Generator
     [GeneratedComClass]
     internal partial class ExcelObserverRtdServer : Rtd.ExcelObserverRtdServer, IRtdServer
     {
+        private const int S_OK = 0;
+        private const int E_NOTIMPL = unchecked((int)0x80004001);
+
         private Dispatcher dispatcher;
 
         public ExcelObserverRtdServer()
@@ -29,22 +32,24 @@ namespace ExcelDna.Integration.ComInterop.Generator
         // IDispatch:
         public int GetTypeInfoCount(out uint pctinfo)
         {
-            throw new NotImplementedException();
+            pctinfo = 0;
+            return S_OK;
         }
 
         public int GetTypeInfo(uint iTInfo, uint lcid, out nint ppTInfo)
         {
-            throw new NotImplementedException();
+            ppTInfo = 0;
+            return E_NOTIMPL;
         }
 
-        public int GetIDsOfNames(Guid riid, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 2)] string[] rgszNames, uint cNames, uint lcid, [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2), Out] int[] rgDispId)
+        public int GetIDsOfNames(in Guid riid, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 2)] string[] rgszNames, uint cNames, uint lcid, [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2), Out] int[] rgDispId)
         {
             dispatcher.GetIDsOfNames(rgszNames, rgDispId);
 
             return 0;
         }
 
-        public int Invoke(int dispIdMember, Guid riid, uint lcid, INVOKEKIND wFlags, [MarshalUsing(typeof(DispParamsMarshaller))] in DispParams pDispParams, nint pVarResult, nint pExcepInfo, nint puArgErr)
+        public int Invoke(int dispIdMember, in Guid riid, uint lcid, ushort wFlags, [MarshalUsing(typeof(DispParamsMarshaller))] in DispParams pDispParams, nint pVarResult, nint pExcepInfo, nint puArgErr)
         {
             dispatcher.Invoke(dispIdMember, pDispParams, pVarResult);
 

--- a/Source/ExcelDna.Integration/ComInterop/Generator/ExcelRibbon.cs
+++ b/Source/ExcelDna.Integration/ComInterop/Generator/ExcelRibbon.cs
@@ -15,6 +15,10 @@ namespace ExcelDna.Integration.ComInterop.Generator
     [GeneratedComClass]
     internal partial class ExcelRibbon : ExcelComAddIn, Interfaces.IDTExtensibility2, Interfaces.IRibbonExtensibility
     {
+        private const int S_OK = 0;
+        private const int E_NOTIMPL = unchecked((int)0x80004001);
+        private const int DISP_E_UNKNOWNNAME = unchecked((int)0x80020006);
+
         private MethodInfo[] methods;
         private CustomUI.IExcelRibbon customRibbon;
 
@@ -26,23 +30,29 @@ namespace ExcelDna.Integration.ComInterop.Generator
 
         public int GetTypeInfoCount(out uint pctinfo)
         {
-            throw new NotImplementedException();
+            pctinfo = 0;
+            return S_OK;
         }
 
         public int GetTypeInfo(uint iTInfo, uint lcid, out nint ppTInfo)
         {
-            throw new NotImplementedException();
+            ppTInfo = 0;
+            return E_NOTIMPL;
         }
 
-        public int GetIDsOfNames(Guid riid, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 2)] string[] rgszNames, uint cNames, uint lcid, [In][Out][MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] int[] rgDispId)
+        public int GetIDsOfNames(in Guid riid, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 2)] string[] rgszNames, uint cNames, uint lcid, [In][Out][MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] int[] rgDispId)
         {
+            bool foundAll = true;
             for (int i = 0; i < cNames; ++i)
+            {
                 rgDispId[i] = (rgszNames[i] == "LoadImage") ? methods.Length : Array.FindIndex(methods, m => m?.Name == rgszNames[i]);
+                foundAll &= rgDispId[i] >= 0;
+            }
 
-            return 0;
+            return foundAll ? S_OK : DISP_E_UNKNOWNNAME;
         }
 
-        public int Invoke(int dispIdMember, Guid riid, uint lcid, INVOKEKIND wFlags, [MarshalUsing(typeof(Generator.Interfaces.DispParamsMarshaller))] in Generator.Interfaces.DispParams pDispParams, nint pVarResult, nint pExcepInfo, nint puArgErr)
+        public int Invoke(int dispIdMember, in Guid riid, uint lcid, ushort wFlags, [MarshalUsing(typeof(Generator.Interfaces.DispParamsMarshaller))] in Generator.Interfaces.DispParams pDispParams, nint pVarResult, nint pExcepInfo, nint puArgErr)
         {
             try
             {
@@ -139,8 +149,17 @@ namespace ExcelDna.Integration.ComInterop.Generator
 
         public int GetCustomUI([MarshalAs(UnmanagedType.BStr)] string RibbonID, [MarshalAs(UnmanagedType.BStr)] out string result)
         {
-            result = customRibbon.GetCustomUI(RibbonID);
-            return 0;
+            try
+            {
+                result = customRibbon.GetCustomUI(RibbonID);
+                return S_OK;
+            }
+            catch (Exception ex)
+            {
+                ExcelDna.Logging.Logger.ComAddIn.Error(ex, "Ribbon GetCustomUI failed");
+                result = string.Empty;
+                return E_NOTIMPL;
+            }
         }
         #endregion
 

--- a/Source/ExcelDna.Integration/ComInterop/Generator/Interfaces/ArrayMarshaller.cs
+++ b/Source/ExcelDna.Integration/ComInterop/Generator/Interfaces/ArrayMarshaller.cs
@@ -1,16 +1,30 @@
 ﻿#if COM_GENERATED
 
+using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace ExcelDna.Integration.ComInterop.Generator.Interfaces
 {
     internal static class ArrayMarshaller
     {
-        public unsafe static nint ArrayToPtr<T>(T[] str)
+        public static nint ArrayToPtr<T>(T[] values)
         {
-            return (nint)Unsafe.AsPointer(ref MemoryMarshal.GetArrayDataReference(str));
+            if (values == null || values.Length == 0)
+                return nint.Zero;
+
+            int size = Marshal.SizeOf<T>();
+            nint result = Marshal.AllocHGlobal(size * values.Length);
+            for (int i = 0; i < values.Length; ++i)
+                Marshal.StructureToPtr(values[i], result + i * size, false);
+
+            return result;
+        }
+
+        public static void FreePtr(nint ptr)
+        {
+            if (ptr != nint.Zero)
+                Marshal.FreeHGlobal(ptr);
         }
 
         public static T[] PtrToArray<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] T>(nint str, int len)

--- a/Source/ExcelDna.Integration/ComInterop/Generator/Interfaces/DispParamsMarshaller.cs
+++ b/Source/ExcelDna.Integration/ComInterop/Generator/Interfaces/DispParamsMarshaller.cs
@@ -11,11 +11,18 @@ namespace ExcelDna.Integration.ComInterop.Generator.Interfaces
     {
         public static unsafe DispParamsNative ConvertToUnmanaged(DispParams managed)
         {
+            int* rgdispidNamedArgs = null;
+            if (managed.rgdispidNamedArgs != 0)
+            {
+                rgdispidNamedArgs = (int*)Marshal.AllocHGlobal(sizeof(int));
+                *rgdispidNamedArgs = managed.rgdispidNamedArgs;
+            }
+
             return new DispParamsNative
             {
                 cArgs = managed.cArgs,
                 cNamedArgs = managed.cNamedArgs,
-                rgdispidNamedArgs = managed.rgdispidNamedArgs != 0 ? &managed.rgdispidNamedArgs : null,
+                rgdispidNamedArgs = rgdispidNamedArgs,
                 rgvarg =
                     managed.rgvarg != null
                         ? ArrayMarshaller.ArrayToPtr(managed.rgvarg.Reverse().Select(VariantMarshaller.ConvertToUnmanaged).ToArray())
@@ -37,6 +44,22 @@ namespace ExcelDna.Integration.ComInterop.Generator.Interfaces
                     .ToArray(),
                 rgvargNative = unmanaged.rgvarg,
             };
+        }
+
+        public static unsafe void Free(DispParamsNative unmanaged)
+        {
+            if (unmanaged.rgvarg != 0)
+            {
+                int size = Marshal.SizeOf<VariantNative>();
+                for (int i = 0; i < unmanaged.cArgs; ++i)
+                {
+                    VariantMarshaller.Free(Marshal.PtrToStructure<VariantNative>(unmanaged.rgvarg + i * size));
+                }
+                ArrayMarshaller.FreePtr(unmanaged.rgvarg);
+            }
+
+            if (unmanaged.rgdispidNamedArgs != null)
+                Marshal.FreeHGlobal((nint)unmanaged.rgdispidNamedArgs);
         }
 
         public static void UpdateArg(DispParams dp, Variant v, int i)

--- a/Source/ExcelDna.Integration/ComInterop/Generator/Interfaces/DispatchObject.cs
+++ b/Source/ExcelDna.Integration/ComInterop/Generator/Interfaces/DispatchObject.cs
@@ -106,7 +106,7 @@ namespace ExcelDna.Integration.ComInterop.Generator.Interfaces
 
             var dispIds = new int[names.Length];
             var hr = dispatch!.GetIDsOfNames(
-                emptyGuid,
+                in emptyGuid,
                 names,
                 (uint)names.Length,
                 LOCALE_USER_DEFAULT,
@@ -126,9 +126,9 @@ namespace ExcelDna.Integration.ComInterop.Generator.Interfaces
 
             var hr = dispatch!.Invoke(
                 dispIds[0],
-                emptyGuid,
+                in emptyGuid,
                 LOCALE_USER_DEFAULT,
-                kind,
+                (ushort)kind,
                 dispParams,
                 variantResult.Ptr,
                 0,

--- a/Source/ExcelDna.Integration/ComInterop/Generator/Interfaces/IDispatch.cs
+++ b/Source/ExcelDna.Integration/ComInterop/Generator/Interfaces/IDispatch.cs
@@ -19,7 +19,7 @@ namespace ExcelDna.Integration.ComInterop.Generator.Interfaces
 
         [PreserveSig]
         int GetIDsOfNames(
-            Guid riid,
+            in Guid riid,
             [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 2)] string[] rgszNames,
             uint cNames,
             uint lcid,
@@ -29,9 +29,9 @@ namespace ExcelDna.Integration.ComInterop.Generator.Interfaces
         [PreserveSig]
         int Invoke(
             int dispIdMember,
-            Guid riid,
+            in Guid riid,
             uint lcid,
-            INVOKEKIND wFlags,
+            ushort wFlags,
             [MarshalUsing(typeof(DispParamsMarshaller))] in DispParams pDispParams,
             nint pVarResult,
             nint pExcepInfo,

--- a/Source/ExcelDna.Integration/ComInterop/Generator/Interfaces/IRibbonControl.cs
+++ b/Source/ExcelDna.Integration/ComInterop/Generator/Interfaces/IRibbonControl.cs
@@ -13,7 +13,7 @@ namespace ExcelDna.Integration.ComInterop.Generator.Interfaces
         int get_Id([MarshalAs(UnmanagedType.BStr)] out string result);
 
         [PreserveSig]
-        int get_Context(nint result);
+        int get_Context(out nint result);
 
         [PreserveSig]
         int get_Tag([MarshalAs(UnmanagedType.BStr)] out string result);

--- a/Source/ExcelDna.Integration/ComInterop/Generator/Interfaces/SafeArray.cs
+++ b/Source/ExcelDna.Integration/ComInterop/Generator/Interfaces/SafeArray.cs
@@ -23,6 +23,9 @@ namespace ExcelDna.Integration.ComInterop.Generator.Interfaces
         [System.Runtime.InteropServices.DllImport("oleaut32.dll", ExactSpelling = true)]
         public static unsafe extern /*SafeArray**/nint SafeArrayCreate(ushort vt, uint cDims, /*SAFEARRAYBOUND**/nint rgsabound);
 
+        [System.Runtime.InteropServices.DllImport("oleaut32.dll", ExactSpelling = true)]
+        public static extern int SafeArrayDestroy(nint psa);
+
         public ushort cDims;
         public ushort fFeatures;
         public uint cbElements;

--- a/Source/ExcelDna.Integration/ComInterop/Generator/Interfaces/UnknownObject.cs
+++ b/Source/ExcelDna.Integration/ComInterop/Generator/Interfaces/UnknownObject.cs
@@ -1,6 +1,7 @@
 ﻿#if COM_GENERATED
 
 using System;
+using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.Marshalling;
 
 namespace ExcelDna.Integration.ComInterop.Generator.Interfaces
@@ -17,7 +18,11 @@ namespace ExcelDna.Integration.ComInterop.Generator.Interfaces
         public unsafe bool HasInterface(ref Guid guid)
         {
             StrategyBasedComWrappers.DefaultIUnknownStrategy.QueryInterface(P.ToPointer(), in guid, out void* ppObj);
-            return ppObj != null;
+            if (ppObj == null)
+                return false;
+
+            Marshal.Release((IntPtr)ppObj);
+            return true;
         }
 
         public unsafe int QueryInterface(ref Guid guid, out IntPtr ppv)

--- a/Source/ExcelDna.Integration/ComInterop/Generator/Interfaces/VariantMarshaller.cs
+++ b/Source/ExcelDna.Integration/ComInterop/Generator/Interfaces/VariantMarshaller.cs
@@ -111,6 +111,7 @@ namespace ExcelDna.Integration.ComInterop.Generator.Interfaces
             Marshal.StructureToPtr(new SAFEARRAYBOUND { cElements = (uint)array.GetLength(1), lLbound = 0 }, pBounds + Marshal.SizeOf<SAFEARRAYBOUND>(), false);
 
             nint psa = SafeArray.SafeArrayCreate((ushort)VariantTypeNative.VT_VARIANT, (uint)array.Rank, pBounds);
+            Marshal.FreeHGlobal(pBounds);
             SafeArray sa = Marshal.PtrToStructure<SafeArray>(psa);
 
             for (int col = 0; col < array.GetLength(1); ++col)
@@ -145,6 +146,21 @@ namespace ExcelDna.Integration.ComInterop.Generator.Interfaces
         {
             short boolVal = v ? (short)VariantBoolNative.VARIANT_TRUE : (short)VariantBoolNative.VARIANT_FALSE;
             Marshal.StructureToPtr(boolVal, unmanaged.pboolVal, false);
+        }
+
+        public static void Free(VariantNative unmanaged)
+        {
+            switch ((VariantTypeNative)unmanaged.vt)
+            {
+                case VariantTypeNative.VT_BSTR:
+                    if (unmanaged.bstrVal != 0)
+                        Marshal.FreeBSTR(unmanaged.bstrVal);
+                    break;
+                case VT_VARIANT_ARRAY:
+                    if (unmanaged.parray != 0)
+                        SafeArray.SafeArrayDestroy(unmanaged.parray);
+                    break;
+            }
         }
     }
 }

--- a/Source/ExcelDna.Integration/ComInterop/Generator/Interfaces/VariantResultMarshaller.cs
+++ b/Source/ExcelDna.Integration/ComInterop/Generator/Interfaces/VariantResultMarshaller.cs
@@ -14,6 +14,7 @@ namespace ExcelDna.Integration.ComInterop.Generator.Interfaces
         public VariantResultMarshaller()
         {
             Ptr = Marshal.AllocHGlobal(Marshal.SizeOf<VariantNative>());
+            Marshal.StructureToPtr(default(VariantNative), Ptr, false);
         }
 
         public Variant GetResult()
@@ -26,6 +27,7 @@ namespace ExcelDna.Integration.ComInterop.Generator.Interfaces
         {
             if (!disposedValue)
             {
+                VariantMarshaller.Free(Marshal.PtrToStructure<VariantNative>(Ptr));
                 Marshal.FreeHGlobal(Ptr);
                 disposedValue = true;
             }

--- a/Source/ExcelDna.Integration/ComInterop/Generator/RTDUpdateEvent.cs
+++ b/Source/ExcelDna.Integration/ComInterop/Generator/RTDUpdateEvent.cs
@@ -10,6 +10,9 @@ namespace ExcelDna.Integration.ComInterop.Generator
     [GeneratedComClass]
     internal partial class RTDUpdateEvent : Rtd.IRTDUpdateEvent, IRTDUpdateEvent
     {
+        private const int S_OK = 0;
+        private const int E_NOTIMPL = unchecked((int)0x80004001);
+
         private IRTDUpdateEvent impl;
 
         public RTDUpdateEvent(IRTDUpdateEvent impl)
@@ -61,22 +64,24 @@ namespace ExcelDna.Integration.ComInterop.Generator
 
         int IDispatch.GetTypeInfoCount(out uint pctinfo)
         {
-            throw new NotImplementedException();
+            pctinfo = 0;
+            return S_OK;
         }
 
         int IDispatch.GetTypeInfo(uint iTInfo, uint lcid, out nint ppTInfo)
         {
-            throw new NotImplementedException();
+            ppTInfo = 0;
+            return E_NOTIMPL;
         }
 
-        int IDispatch.GetIDsOfNames(Guid riid, string[] rgszNames, uint cNames, uint lcid, int[] rgDispId)
+        int IDispatch.GetIDsOfNames(in Guid riid, string[] rgszNames, uint cNames, uint lcid, int[] rgDispId)
         {
-            throw new NotImplementedException();
+            return E_NOTIMPL;
         }
 
-        int IDispatch.Invoke(int dispIdMember, Guid riid, uint lcid, INVOKEKIND wFlags, in DispParams pDispParams, nint pVarResult, nint pExcepInfo, nint puArgErr)
+        int IDispatch.Invoke(int dispIdMember, in Guid riid, uint lcid, ushort wFlags, in DispParams pDispParams, nint pVarResult, nint pExcepInfo, nint puArgErr)
         {
-            throw new NotImplementedException();
+            return E_NOTIMPL;
         }
     }
 }

--- a/Source/ExcelDna.Integration/ComInterop/Util.cs
+++ b/Source/ExcelDna.Integration/ComInterop/Util.cs
@@ -30,12 +30,20 @@ namespace ExcelDna.Integration.ComInterop
         public static int QueryInterfaceForObject(object o, Guid guid, out IntPtr ppv)
         {
             Guid iid = guid;
+            IntPtr pUnk = GetIUnknownForObject(o);
 
-            return Marshal.QueryInterface(GetIUnknownForObject(o),
+            try
+            {
+                return Marshal.QueryInterface(pUnk,
 #if !COM_GENERATED
-            ref
+                ref
 #endif
-            iid, out ppv);
+                iid, out ppv);
+            }
+            finally
+            {
+                Marshal.Release(pUnk);
+            }
         }
 
         private static IntPtr GetIUnknownForObject(object o)

--- a/Source/ExcelDna.Integration/CustomUI/RibbonControl.cs
+++ b/Source/ExcelDna.Integration/CustomUI/RibbonControl.cs
@@ -1,4 +1,6 @@
-﻿#if COM_GENERATED
+#if COM_GENERATED
+
+using System.Runtime.InteropServices;
 
 namespace ExcelDna.Integration.CustomUI
 {
@@ -21,6 +23,19 @@ namespace ExcelDna.Integration.CustomUI
             {
                 control.get_Tag(out string result);
                 return result;
+            }
+        }
+
+        public object Context
+        {
+            get
+            {
+                int hr = control.get_Context(out nint result);
+                Marshal.ThrowExceptionForHR(hr);
+                if (result == 0)
+                    return null;
+
+                return new ComInterop.Generator.DynamicComObject(new ComInterop.Generator.Interfaces.DispatchObject(result));
             }
         }
 

--- a/Source/ExcelDna.SourceGenerator.NativeAOT/Generator.cs
+++ b/Source/ExcelDna.SourceGenerator.NativeAOT/Generator.cs
@@ -78,7 +78,7 @@ namespace ExcelDna.SourceGenerator.NativeAOT
                     {
                         if (actions.Length > 0)
                             actions += ",\r\n";
-                        actions += $"typeof({Util.GetFullTypeName(m.ContainingType)}).GetMethod(\"{m.Name}\")!";
+                        actions += GetMethod(m);
                     }
 
                     addIns += $"{regHost}.ExcelAddIns.Add(new ExcelDna.Integration.TypeHelper<{Util.GetFullTypeName(i.Type)}>([{actions}]));\r\n";
@@ -221,7 +221,18 @@ namespace ExcelDna.SourceGenerator.NativeAOT
 
         private static string GetMethod(IMethodSymbol method)
         {
-            return $"typeof({Util.GetFullTypeName(method.ContainingType)}).GetMethod(\"{method.Name}\")!";
+            return $"typeof({Util.GetFullTypeName(method.ContainingType)}).GetMethod(\"{method.Name}\", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, null, new Type[] {{ {GetParameterTypes(method)} }}, null)!";
+        }
+
+        private static string GetParameterTypes(IMethodSymbol method)
+        {
+            return string.Join(", ", method.Parameters.Select(GetParameterType));
+        }
+
+        private static string GetParameterType(IParameterSymbol parameter)
+        {
+            string type = $"typeof({Util.GetFullTypeOfTypeName(parameter.Type)})";
+            return parameter.RefKind == RefKind.None ? type : $"{type}.MakeByRefType()";
         }
 
         private static string GetTypeRefs(string methodType, string extendedMethodType, int parameterCount)

--- a/Source/ExcelDna.SourceGenerator.NativeAOT/Util.cs
+++ b/Source/ExcelDna.SourceGenerator.NativeAOT/Util.cs
@@ -11,6 +11,11 @@ namespace ExcelDna.SourceGenerator.NativeAOT
             return type.ToDisplayString().Replace("[*,*]", "[,]");
         }
 
+        public static string GetFullTypeOfTypeName(ITypeSymbol type)
+        {
+            return type.ToDisplayString(FullTypeOfTypeNameFormat).Replace("[*,*]", "[,]");
+        }
+
         public static string GetFullGenericTypeName(INamedTypeSymbol type)
         {
             return type.ToDisplayString(FullGenericNameFormat);
@@ -342,5 +347,9 @@ namespace ExcelDna.SourceGenerator.NativeAOT
 
         private static SymbolDisplayFormat FullNameFormat = new SymbolDisplayFormat(typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
         private static SymbolDisplayFormat FullGenericNameFormat = new SymbolDisplayFormat(typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces, genericsOptions: SymbolDisplayGenericsOptions.None);
+        private static SymbolDisplayFormat FullTypeOfTypeNameFormat = new SymbolDisplayFormat(
+            typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+            genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+            miscellaneousOptions: SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers | SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
     }
 }

--- a/Source/ExcelDna.TestAOT/ExcelDna.TestAOT.csproj
+++ b/Source/ExcelDna.TestAOT/ExcelDna.TestAOT.csproj
@@ -8,15 +8,21 @@
     
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-x64</RuntimeIdentifier>
     <PublishAOT>true</PublishAOT>
     <SelfContained>true</SelfContained>
-    <TargetName>ExcelDna.TestAOT64</TargetName>
 
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ExcelDnaNativeAOTPlatform Condition="'$(ExcelDnaNativeAOTPlatform)' == '' And $(RuntimeIdentifier.EndsWith('-x86'))">x86</ExcelDnaNativeAOTPlatform>
+    <ExcelDnaNativeAOTPlatform Condition="'$(ExcelDnaNativeAOTPlatform)' == ''">x64</ExcelDnaNativeAOTPlatform>
+    <ExcelDnaNativeAOTBitnessSuffix Condition="'$(ExcelDnaNativeAOTPlatform)' == 'x64'">64</ExcelDnaNativeAOTBitnessSuffix>
+    <TargetName Condition="'$(TargetName)' == ''">ExcelDna.TestAOT$(ExcelDnaNativeAOTBitnessSuffix)</TargetName>
+    <ExcelDnaNativeAOTLoaderPath>$(MSBuildProjectDirectory)\..\ExcelDna.Host.NativeAOT\bin\$(Configuration)\$(ExcelDnaNativeAOTPlatform)\ExcelDna.Host.NativeAOT.$(ExcelDnaNativeAOTPlatform).xll</ExcelDnaNativeAOTLoaderPath>
   </PropertyGroup>
 
   <Target Name="SetNoBuild">
@@ -24,7 +30,7 @@
       <NoBuild>true</NoBuild>
     </PropertyGroup>
   </Target>
-  <Target Name="PublishAfterBuild" AfterTargets="AfterBuild" DependsOnTargets="SetNoBuild;Publish" />
+  <Target Name="PublishAfterBuild" AfterTargets="AfterBuild" DependsOnTargets="SetNoBuild;Publish" Condition="'$(_IsPublishing)' != 'true'" />
   <ItemGroup>
     <None Remove="app.ico" />
     <None Remove="Package.ico" />
@@ -39,8 +45,12 @@
     <ProjectReference Include="..\ExcelDna.SourceGenerator.NativeAOT\ExcelDna.SourceGenerator.NativeAOT.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
-  <Target Name="PostBuildAOT" AfterTargets="PublishAfterBuild">
-    <Exec Command="xcopy /y &quot;$(SolutionDir)ExcelDna.Host.NativeAOT\bin\$(ConfigurationName)\x64\ExcelDna.Host.NativeAOT.x64.xll&quot; &quot;$(TargetDir)publish\ExcelDna.TestAOT64.xll*&quot;&#xD;&#xA;" />
+  <Target Name="PostBuildAOT" AfterTargets="Publish">
+    <Copy SourceFiles="$(ExcelDnaNativeAOTLoaderPath)"
+          DestinationFiles="$(PublishDir)$(TargetName).xll"
+          Condition="Exists('$(ExcelDnaNativeAOTLoaderPath)')" />
+    <Warning Condition="!Exists('$(ExcelDnaNativeAOTLoaderPath)')"
+             Text="NativeAOT loader was not found at '$(ExcelDnaNativeAOTLoaderPath)'; build ExcelDna.Host.NativeAOT for $(ExcelDnaNativeAOTPlatform) to produce the .xll loader." />
   </Target>
 
 </Project>

--- a/Source/Tests/ExcelDna.AddIn.RuntimeTestsAOT/ExcelDna.AddIn.RuntimeTestsAOT.csproj
+++ b/Source/Tests/ExcelDna.AddIn.RuntimeTestsAOT/ExcelDna.AddIn.RuntimeTestsAOT.csproj
@@ -8,15 +8,21 @@
     
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-x64</RuntimeIdentifier>
     <PublishAOT>true</PublishAOT>
     <SelfContained>true</SelfContained>
-    <TargetName>ExcelDna.AddIn.RuntimeTestsAOT64</TargetName>
 
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ExcelDnaNativeAOTPlatform Condition="'$(ExcelDnaNativeAOTPlatform)' == '' And $(RuntimeIdentifier.EndsWith('-x86'))">x86</ExcelDnaNativeAOTPlatform>
+    <ExcelDnaNativeAOTPlatform Condition="'$(ExcelDnaNativeAOTPlatform)' == ''">x64</ExcelDnaNativeAOTPlatform>
+    <ExcelDnaNativeAOTBitnessSuffix Condition="'$(ExcelDnaNativeAOTPlatform)' == 'x64'">64</ExcelDnaNativeAOTBitnessSuffix>
+    <TargetName Condition="'$(TargetName)' == ''">ExcelDna.AddIn.RuntimeTestsAOT$(ExcelDnaNativeAOTBitnessSuffix)</TargetName>
+    <ExcelDnaNativeAOTLoaderPath>$(MSBuildProjectDirectory)\..\..\ExcelDna.Host.NativeAOT\bin\$(Configuration)\$(ExcelDnaNativeAOTPlatform)\ExcelDna.Host.NativeAOT.$(ExcelDnaNativeAOTPlatform).xll</ExcelDnaNativeAOTLoaderPath>
   </PropertyGroup>
 
   <Target Name="SetNoBuild">
@@ -24,15 +30,19 @@
       <NoBuild>true</NoBuild>
     </PropertyGroup>
   </Target>
-  <Target Name="PublishAfterBuild" AfterTargets="AfterBuild" DependsOnTargets="SetNoBuild;Publish" />
+  <Target Name="PublishAfterBuild" AfterTargets="AfterBuild" DependsOnTargets="SetNoBuild;Publish" Condition="'$(_IsPublishing)' != 'true'" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\ExcelDna.ManagedHost\ExcelDna.ManagedHost.csproj" />
     <ProjectReference Include="..\..\ExcelDna.SourceGenerator.NativeAOT\ExcelDna.SourceGenerator.NativeAOT.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
-  <Target Name="PostBuildAOT" AfterTargets="PublishAfterBuild">
-    <Exec Command="xcopy /y &quot;$(SolutionDir)ExcelDna.Host.NativeAOT\bin\$(ConfigurationName)\x64\ExcelDna.Host.NativeAOT.x64.xll&quot; &quot;$(TargetDir)publish\ExcelDna.AddIn.RuntimeTestsAOT64.xll*&quot;&#xD;&#xA;" />
+  <Target Name="PostBuildAOT" AfterTargets="Publish">
+    <Copy SourceFiles="$(ExcelDnaNativeAOTLoaderPath)"
+          DestinationFiles="$(PublishDir)$(TargetName).xll"
+          Condition="Exists('$(ExcelDnaNativeAOTLoaderPath)')" />
+    <Warning Condition="!Exists('$(ExcelDnaNativeAOTLoaderPath)')"
+             Text="NativeAOT loader was not found at '$(ExcelDnaNativeAOTLoaderPath)'; build ExcelDna.Host.NativeAOT for $(ExcelDnaNativeAOTPlatform) to produce the .xll loader." />
   </Target>
 
 </Project>

--- a/Source/Tests/ExcelDna.SourceGenerator.NativeAOT.Tests/Generator.cs
+++ b/Source/Tests/ExcelDna.SourceGenerator.NativeAOT.Tests/Generator.cs
@@ -27,7 +27,7 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
                 }
                 """, functions: """
                 List<Type> typeRefs = new List<Type>();
-                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeParamsJoinString")!);
+                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeParamsJoinString", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, null, new Type[] { typeof(string), typeof(string[]) }, null)!);
                 typeRefs.Add(typeof(Func<string, string[], string>));
                 typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<string, string[], string>>));
                 typeRefs.Add(typeof(ExcelDna.Integration.ExtendedFunc2<string, string[], string>));
@@ -68,7 +68,7 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
                 }
                 """, functions: """
                 List<Type> typeRefs = new List<Type>();
-                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeOptional")!);
+                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeOptional", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, null, new Type[] { typeof(object), typeof(double), typeof(int), typeof(bool) }, null)!);
                 typeRefs.Add(typeof(Func<object, double, int, bool, string>));
                 typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<object, double, int, bool, string>>));
                 typeRefs.Add(typeof(ExcelDna.Integration.ExtendedFunc4<object, double, int, bool, string>));
@@ -110,7 +110,7 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
                 }
                 """, functions: """
                 List<Type> typeRefs = new List<Type>();
-                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeTaskBool")!);
+                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeTaskBool", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, null, new Type[] {  }, null)!);
                 typeRefs.Add(typeof(Func<System.Threading.Tasks.Task<bool>>));
                 typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<System.Threading.Tasks.Task<bool>>>));
                 typeRefs.Add(typeof(ExcelDna.Integration.ExtendedFunc0<System.Threading.Tasks.Task<bool>>));
@@ -183,7 +183,7 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
                 }
                 """, functions: """
                 List<Type> typeRefs = new List<Type>();
-                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeStringObservable")!);
+                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeStringObservable", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, null, new Type[] { typeof(string) }, null)!);
                 typeRefs.Add(typeof(Func<string, System.IObservable<string>>));
                 typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<string, System.IObservable<string>>>));
                 typeRefs.Add(typeof(ExcelDna.Integration.ExtendedFunc1<string, System.IObservable<string>>));
@@ -220,7 +220,7 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
                 }
                 """, functions: """
                 List<Type> typeRefs = new List<Type>();
-                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeAsyncBool")!);
+                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeAsyncBool", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, null, new Type[] {  }, null)!);
                 typeRefs.Add(typeof(Func<bool>));
                 typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<bool>>));
                 typeRefs.Add(typeof(ExcelDna.Integration.ExtendedFunc0<bool>));
@@ -257,7 +257,7 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
                 }
                 """, functions: """
                 List<Type> typeRefs = new List<Type>();
-                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeAsyncArgs17")!);
+                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeAsyncArgs17", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, null, new Type[] { typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int) }, null)!);
                 typeRefs.Add(typeof(ExcelDna.Integration.ExtendedFunc17<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, bool>));
                 typeRefs.Add(typeof(System.Linq.Expressions.Expression<ExcelDna.Integration.ExtendedFunc17<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, bool>>));
                 typeRefs.Add(typeof(ExcelDna.Integration.ExtendedFunc17<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, object>));
@@ -335,7 +335,7 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
                     }
                 }
                 """, parameterConversions: """
-                ExcelDna.Registration.StaticRegistration.ExcelParameterConversions.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Conversions).GetMethod("ToVersion")!);
+                ExcelDna.Registration.StaticRegistration.ExcelParameterConversions.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Conversions).GetMethod("ToVersion", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, null, new Type[] { typeof(string) }, null)!);
 
                 """);
         }
@@ -369,7 +369,7 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
                 }
                 """, functions: """
                 List<Type> typeRefs = new List<Type>();
-                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeVersion17")!);
+                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeVersion17", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, null, new Type[] { typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(int), typeof(System.Version) }, null)!);
                 typeRefs.Add(typeof(ExcelDna.Integration.ExtendedFunc17<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, System.Version, string>));
                 typeRefs.Add(typeof(System.Linq.Expressions.Expression<ExcelDna.Integration.ExtendedFunc17<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, System.Version, string>>));
                 typeRefs.Add(typeof(ExcelDna.Integration.ExtendedFunc17<int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, int, string, string>));
@@ -411,7 +411,7 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
 
                 List<MethodInfo> methodRefs = new List<MethodInfo>();
                 """, parameterConversions: """
-                ExcelDna.Registration.StaticRegistration.ExcelParameterConversions.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Conversions).GetMethod("ToVersion")!);
+                ExcelDna.Registration.StaticRegistration.ExcelParameterConversions.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Conversions).GetMethod("ToVersion", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, null, new Type[] { typeof(string) }, null)!);
 
                 """);
         }
@@ -445,7 +445,7 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
                 }
                 """, returnConversions: """
 
-                ExcelDna.Registration.StaticRegistration.ExcelReturnConversions.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Conversions).GetMethod("FromTestType1")!);
+                ExcelDna.Registration.StaticRegistration.ExcelReturnConversions.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Conversions).GetMethod("FromTestType1", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, null, new Type[] { typeof(ExcelDna.AddIn.RuntimeTestsAOT.TestType1) }, null)!);
                 """);
         }
 
@@ -487,7 +487,7 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
                 }
                 """, functions: """
                 List<Type> typeRefs = new List<Type>();
-                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeReturnTestType1")!);
+                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeReturnTestType1", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, null, new Type[] { typeof(string) }, null)!);
                 typeRefs.Add(typeof(Func<string, ExcelDna.AddIn.RuntimeTestsAOT.TestType1>));
                 typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<string, ExcelDna.AddIn.RuntimeTestsAOT.TestType1>>));
                 typeRefs.Add(typeof(ExcelDna.Integration.ExtendedFunc1<string, ExcelDna.AddIn.RuntimeTestsAOT.TestType1>));
@@ -502,7 +502,7 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
                 List<MethodInfo> methodRefs = new List<MethodInfo>();
                 """, returnConversions: """
 
-                ExcelDna.Registration.StaticRegistration.ExcelReturnConversions.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Conversions).GetMethod("FromTestType1")!);
+                ExcelDna.Registration.StaticRegistration.ExcelReturnConversions.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Conversions).GetMethod("FromTestType1", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, null, new Type[] { typeof(ExcelDna.AddIn.RuntimeTestsAOT.TestType1) }, null)!);
                 """);
         }
 
@@ -537,7 +537,7 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
                 }
                 """, functions: """
                 List<Type> typeRefs = new List<Type>();
-                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeCreateCalc")!);
+                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeCreateCalc", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, null, new Type[] { typeof(double), typeof(double) }, null)!);
                 typeRefs.Add(typeof(Func<double, double, ExcelDna.AddIn.RuntimeTestsAOT.Calc>));
                 typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<double, double, ExcelDna.AddIn.RuntimeTestsAOT.Calc>>));
                 typeRefs.Add(typeof(ExcelDna.Integration.ExtendedFunc2<double, double, ExcelDna.AddIn.RuntimeTestsAOT.Calc>));
@@ -551,7 +551,7 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
                 typeRefs.Add(typeof(Func<object, double>));
                 typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<object, double>>));
 
-                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeCalcSum")!);
+                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeCalcSum", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, null, new Type[] { typeof(ExcelDna.AddIn.RuntimeTestsAOT.Calc) }, null)!);
                 typeRefs.Add(typeof(Func<ExcelDna.AddIn.RuntimeTestsAOT.Calc, double>));
                 typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<ExcelDna.AddIn.RuntimeTestsAOT.Calc, double>>));
                 typeRefs.Add(typeof(ExcelDna.Integration.ExtendedFunc1<ExcelDna.AddIn.RuntimeTestsAOT.Calc, double>));
@@ -587,7 +587,75 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
                 }
                 """, executionHandlers: """
 
-                ExcelDna.Registration.StaticRegistration.ExcelFunctionExecutionHandlerSelectors.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.FunctionLoggingHandler).GetMethod("LoggingHandlerSelector")!);
+                ExcelDna.Registration.StaticRegistration.ExcelFunctionExecutionHandlerSelectors.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.FunctionLoggingHandler).GetMethod("LoggingHandlerSelector", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, null, new Type[] { typeof(ExcelDna.Integration.IExcelFunctionInfo) }, null)!);
+                """);
+        }
+
+        [Fact]
+        public void OverloadedMethodsUseParameterTypes()
+        {
+            Verify("""
+                using ExcelDna.Integration;
+
+                namespace ExcelDna.AddIn.RuntimeTestsAOT
+                {
+                    public class Functions
+                    {
+                        public static string NativeOverload(string value)
+                        {
+                            return value;
+                        }
+
+                        [ExcelFunction]
+                        public static string NativeOverload(double value)
+                        {
+                            return value.ToString();
+                        }
+                    }
+                }
+                """, functions: """
+                List<Type> typeRefs = new List<Type>();
+                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeOverload", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, null, new Type[] { typeof(double) }, null)!);
+                typeRefs.Add(typeof(Func<double, string>));
+                typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<double, string>>));
+                typeRefs.Add(typeof(ExcelDna.Integration.ExtendedFunc1<double, string>));
+                typeRefs.Add(typeof(System.Linq.Expressions.Expression<ExcelDna.Integration.ExtendedFunc1<double, string>>));
+                typeRefs.Add(typeof(Func<object, double>));
+                typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<object, double>>));
+
+                List<MethodInfo> methodRefs = new List<MethodInfo>();
+                """);
+        }
+
+        [Fact]
+        public void NullableReferenceParametersUseRuntimeTypesForMethodLookup()
+        {
+            Verify("""
+                #nullable enable
+                using ExcelDna.Integration;
+
+                namespace ExcelDna.AddIn.RuntimeTestsAOT
+                {
+                    public class Functions
+                    {
+                        [ExcelFunction]
+                        public static string? NativeNullable(string? value)
+                        {
+                            return value;
+                        }
+                    }
+                }
+                """, functions: """
+                List<Type> typeRefs = new List<Type>();
+                ExcelDna.Registration.StaticRegistration.MethodsForRegistration.Add(typeof(ExcelDna.AddIn.RuntimeTestsAOT.Functions).GetMethod("NativeNullable", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance, null, new Type[] { typeof(string) }, null)!);
+                typeRefs.Add(typeof(Func<string?, string?>));
+                typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<string?, string?>>));
+                typeRefs.Add(typeof(ExcelDna.Integration.ExtendedFunc1<string?, string?>));
+                typeRefs.Add(typeof(System.Linq.Expressions.Expression<ExcelDna.Integration.ExtendedFunc1<string?, string?>>));
+                typeRefs.Add(typeof(Func<object, string?>));
+                typeRefs.Add(typeof(System.Linq.Expressions.Expression<Func<object, string?>>));
+
+                List<MethodInfo> methodRefs = new List<MethodInfo>();
                 """);
         }
 
@@ -669,4 +737,3 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
         }
     }
 }
-

--- a/Source/Tests/ExcelDna.SourceGenerator.NativeAOT.Tests/RibbonDispatch.cs
+++ b/Source/Tests/ExcelDna.SourceGenerator.NativeAOT.Tests/RibbonDispatch.cs
@@ -37,7 +37,8 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
         private static int GetDispId(ExcelRibbon ribbon, string name)
         {
             int[] ids = new int[1];
-            ribbon.GetIDsOfNames(Guid.Empty, new[] { name }, 1, 0, ids);
+            Guid riid = Guid.Empty;
+            ribbon.GetIDsOfNames(in riid, new[] { name }, 1, 0, ids);
             return ids[0];
         }
 
@@ -53,7 +54,8 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
             try
             {
                 Marshal.StructureToPtr(default(VariantNative), pVarResult, false);
-                ribbon.Invoke(dispId, Guid.Empty, 0, INVOKEKIND.INVOKE_FUNC, in dispParams, pVarResult, 0, 0);
+                Guid riid = Guid.Empty;
+                ribbon.Invoke(dispId, in riid, 0, (ushort)INVOKEKIND.INVOKE_FUNC, in dispParams, pVarResult, 0, 0);
                 return VariantMarshaller.ConvertToManaged(Marshal.PtrToStructure<VariantNative>(pVarResult)).Value;
             }
             finally
@@ -76,6 +78,20 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
             Assert.True(GetDispId(ribbon, "DoesNotExist") < 0);
             // LoadImage is the built-in callback dispatched past the end of the methods array.
             Assert.True(GetDispId(ribbon, "LoadImage") >= 0);
+        }
+
+        [Fact]
+        public void IDispatch_TypeInfoProbes_ReturnHResults()
+        {
+            ExcelRibbon ribbon = CreateRibbon();
+
+            int countHr = ribbon.GetTypeInfoCount(out uint count);
+            int typeInfoHr = ribbon.GetTypeInfo(0, 0, out nint typeInfo);
+
+            Assert.Equal(0, countHr);
+            Assert.Equal(0u, count);
+            Assert.NotEqual(0, typeInfoHr);
+            Assert.Equal(0, typeInfo);
         }
 
         [Fact]
@@ -108,7 +124,8 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
             ExcelRibbon ribbon = CreateRibbon();
             TestRibbon.LastPressed = false;
             DispParams dispParams = new DispParams { cArgs = 2, rgvarg = new[] { new Variant(null), new Variant(true) } };
-            ribbon.Invoke(GetDispId(ribbon, "OnToggle"), Guid.Empty, 0, INVOKEKIND.INVOKE_FUNC, in dispParams, 0, 0, 0);
+            Guid riid = Guid.Empty;
+            ribbon.Invoke(GetDispId(ribbon, "OnToggle"), in riid, 0, (ushort)INVOKEKIND.INVOKE_FUNC, in dispParams, 0, 0, 0);
             Assert.True(TestRibbon.LastPressed);
         }
 
@@ -118,7 +135,8 @@ namespace ExcelDna.SourceGenerator.NativeAOT.Tests
             ExcelRibbon ribbon = CreateRibbon();
             TestRibbon.LastText = null;
             DispParams dispParams = new DispParams { cArgs = 2, rgvarg = new[] { new Variant(null), new Variant("hello") } };
-            ribbon.Invoke(GetDispId(ribbon, "OnChange"), Guid.Empty, 0, INVOKEKIND.INVOKE_FUNC, in dispParams, 0, 0, 0);
+            Guid riid = Guid.Empty;
+            ribbon.Invoke(GetDispId(ribbon, "OnChange"), in riid, 0, (ushort)INVOKEKIND.INVOKE_FUNC, in dispParams, 0, 0, 0);
             Assert.Equal("hello", TestRibbon.LastText);
         }
     }


### PR DESCRIPTION
Fix NativeAOT COM/Ribbon interop and AOT publish flow

Correct generated COM dispatch signatures and HRESULT behavior, tighten
NativeAOT VARIANT/DISPPARAMS ownership, restore RibbonControl.Context, emit
exact source-generator method lookups for overloads, and fix x86/x64 AOT
publish targets.